### PR TITLE
fix(templates,distribution): don't set common tolerations and nodeSelector when empty

### DIFF
--- a/templates/distribution/terraform/eks-addons.tf.tpl
+++ b/templates/distribution/terraform/eks-addons.tf.tpl
@@ -9,6 +9,7 @@ module "eks_addons" {
     service_account_role_arn = module.ebs_csi_driver_iam_role.ebs_csi_driver_iam_role_arn
     configuration_values = jsonencode({
       controller =  {
+          {{- if index .spec.distribution.common "tolerations" }}
           tolerations = [
             {{- range $toleration := .spec.distribution.common.tolerations }}
             {
@@ -24,18 +25,22 @@ module "eks_addons" {
             }
           {{- end }}
           ]
+          {{- end }}
+          {{- if index .spec.distribution.common "nodeSelector" }}
           nodeSelector = {
             {{- range $k,$v := .spec.distribution.common.nodeSelector }}
               "{{ $k }}" = "{{ $v }}"
             {{- end }}
           }
+          {{- end }}
         }
     })
   }
   coredns = {
     configuration_values = jsonencode({
+      {{- if index .spec.distribution.common "tolerations" }}
       tolerations = [
-        {{- range $toleration := .spec.distribution.common.tolerations }}
+      {{- range $toleration := .spec.distribution.common.tolerations }}
         {
           {{- if $toleration.key }}
           key = "{{ $toleration.key }}"
@@ -49,15 +54,20 @@ module "eks_addons" {
         }
       {{- end }}
       ]
+      {{- end }}
+      {{- if index .spec.distribution.common "nodeSelector" }}
       nodeSelector = {
         {{- range $k,$v := .spec.distribution.common.nodeSelector }}
           "{{ $k }}" = "{{ $v }}"
         {{- end }}
       }
+      {{- end }}
     })
   }
   snapshot_controller = {
+    service_account_role_arn = module.ebs_csi_driver_iam_role.ebs_csi_driver_iam_role_arn
     configuration_values = jsonencode({
+      {{- if index .spec.distribution.common "tolerations" }}
       tolerations = [
         {{- range $toleration := .spec.distribution.common.tolerations }}
         {
@@ -73,11 +83,15 @@ module "eks_addons" {
         }
       {{- end }}
       ]
+      {{- end }}
+      {{- if index .spec.distribution.common "nodeSelector" }}
       nodeSelector = {
         {{- range $k,$v := .spec.distribution.common.nodeSelector }}
           "{{ $k }}" = "{{ $v }}"
         {{- end }}
       }
+      {{- end }}
     })
   }
 }
+


### PR DESCRIPTION
### Summary 💡

This PR fix empty common nodeSelectors and tolerations in EKS addons terraform template.

<!--
If there's an existing issue for your change, please link to it below inserting a link or the issue number.

If there's _not_ an existing issue, please open one first if the problem you are solving needs to be clearly identified,
for example is an error message that other users could get and google it.
-->


<!-- If this PR is related to changes produced in other repos, like a Module, please link them below. -->
Relates: https://github.com/sighupio/distribution/pull/367


### Description 📝

Edit EKS addon terraform template

### Breaking Changes 💔

<!--
If this PR introduces Breaking Changes, please include all the relevant information:
- What is changing
- What should the process for updating be
- Include examples if you can
-->

### Tests performed 🧪

<!--
Create a checklist with all the tests that you performed on your changes, being manual or automated.

If you are opening a Draft PR, you can use the checklist to track the tests that you want to do and mark them once you have performed them.

Example:

- [ ] Tested the change with KFD version X.Y.Z
- [ ] Tested an upgrade from the previous version X
-->

- [x] Tested without common nodeSelectors and tolerations
- [x] Tested with common nodeSelectors and tolerations


### Future work 🔧

<!--
If there's any future work that could improve or extend on the work you've done in this PR you can mention it so
this PR can be used as context for that.
-->
