### PR TITLE
Feat/upgrade logging module v5.0.0

### DIFF
--- a/templates/distribution/manifests/logging/kustomization.yaml.tpl
+++ b/templates/distribution/manifests/logging/kustomization.yaml.tpl
@@ -171,11 +171,16 @@ patches:
 {{- if or (eq $loggingType "opensearch") (eq $loggingType "loki") }}
 secretGenerator:
   {{- if eq $loggingType "loki" }}
-  - name: loki-distributed
+  - name: loki
     namespace: logging
     behavior: merge
     files:
       - config.yaml=patches/loki-config.yaml
+  - name: minio-credentials-loki
+    namespace: logging
+    behavior: replace
+    envs:
+      - patches/minio.credentials.loki.env
   {{- end }}
   - name: minio-logging
     namespace: logging

--- a/templates/distribution/manifests/logging/patches/infra-nodes.yml.tpl
+++ b/templates/distribution/manifests/logging/patches/infra-nodes.yml.tpl
@@ -81,7 +81,7 @@ spec:
         {{ template "tolerations" $lokiArgs }}
 ---
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: loki-distributed-querier
   namespace: logging
@@ -94,7 +94,7 @@ spec:
         {{ template "tolerations" $lokiArgs }}
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: loki-distributed-compactor
   namespace: logging
@@ -136,6 +136,32 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: loki-distributed-query-frontend
+  namespace: logging
+spec:
+  template:
+    spec:
+      nodeSelector:
+        {{ template "nodeSelector" $lokiArgs }}
+      tolerations:
+        {{ template "tolerations" $lokiArgs }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loki-distributed-query-frontend
+  namespace: logging
+spec:
+  template:
+    spec:
+      nodeSelector:
+        {{ template "nodeSelector" $lokiArgs }}
+      tolerations:
+        {{ template "tolerations" $lokiArgs }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: loki-distributed-index-gateway
   namespace: logging
 spec:
   template:

--- a/templates/distribution/manifests/logging/patches/loki-config.yaml.tpl
+++ b/templates/distribution/manifests/logging/patches/loki-config.yaml.tpl
@@ -115,6 +115,10 @@ storage_config:
   bloom_shipper:
     working_directory: /var/loki/data/bloomshipper
   boltdb_shipper:
+    active_index_directory: /var/loki/index
+    cache_location: /var/loki/cache
+    cache_ttl: 24h
+    resync_interval: 5s
     index_gateway_client:
       server_address: dns+loki-distributed-index-gateway-headless.logging.svc.cluster.local:9095
   hedging:
@@ -122,6 +126,10 @@ storage_config:
     max_per_second: 20
     up_to: 3
   tsdb_shipper:
+    active_index_directory: /var/loki/index
+    cache_location: /var/loki/cache
+    cache_ttl: 24h
+    resync_interval: 5s
     index_gateway_client:
       server_address: dns+loki-distributed-index-gateway-headless.logging.svc.cluster.local:9095
 tracing:

--- a/templates/distribution/manifests/logging/patches/loki-config.yaml.tpl
+++ b/templates/distribution/manifests/logging/patches/loki-config.yaml.tpl
@@ -1,117 +1,131 @@
-# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2025-present SIGHUP s.r.l. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
+#
 
 analytics:
   reporting_enabled: false
 auth_enabled: false
-chunk_store_config:
-  max_look_back_period: 0s
-common:
-  compactor_address: http://loki-distributed-compactor:3100
-compactor:
-  shared_store: filesystem
+bloom_build:
+  builder:
+    planner_address: loki-distributed-bloom-planner-headless.logging.svc.cluster.local:9095
+  enabled: false
 distributor:
   ring:
     kvstore:
       store: memberlist
+bloom_gateway:
+  client:
+    addresses: dnssrvnoa+_grpc._tcp.loki-distributed-bloom-gateway-headless.logging.svc.cluster.local
+  enabled: false
+common:
+  compactor_address: 'http://loki-distributed-compactor:3100'
+  path_prefix: /var/loki
+  replication_factor: 1
+  storage:
+    s3:
+{{- if eq .spec.distribution.modules.logging.loki.backend "minio" }}
+      bucketnames: loki
+      endpoint: http://minio-logging.logging.svc.cluster.local:9000
+      insecure: true
+      access_key_id: ${MINIO_ACCESS_KEY}
+      secret_access_key: ${MINIO_SECRET_KEY}
+      s3forcepathstyle: true
+{{- end }}
+{{- if eq .spec.distribution.modules.logging.loki.backend "externalEndpoint" }}
+      bucketnames: {{ .spec.distribution.modules.logging.loki.externalEndpoint.bucketName }}
+      endpoint: {{ ternary "http" "https" .spec.distribution.modules.logging.loki.externalEndpoint.insecure }}://{{ .spec.distribution.modules.logging.loki.externalEndpoint.endpoint }}
+      insecure: {{ ternary "true" "false" .spec.distribution.modules.logging.loki.externalEndpoint.insecure }}
+      access_key_id: ${MINIO_ACCESS_KEY}
+      secret_access_key: ${MINIO_SECRET_KEY}
+      s3forcepathstyle: true
+{{- end }}
 frontend:
   compress_responses: true
-  log_queries_longer_than: 5s
-  tail_proxy_url: http://loki-distributed-querier:3100
+  log_queries_longer_than: 5s 
+  scheduler_address: loki-distributed-query-scheduler.logging.svc.cluster.local:9095
+  tail_proxy_url: http://loki-distributed-querier.logging.svc.cluster.local:3100
 frontend_worker:
-  frontend_address: loki-distributed-query-frontend-headless:9095
+  scheduler_address: loki-distributed-query-scheduler.logging.svc.cluster.local:9095
+index_gateway:
+  mode: simple
 ingester:
   chunk_block_size: 262144
-  chunk_encoding: snappy
   chunk_idle_period: 30m
   chunk_retain_period: 1m
+  chunk_encoding: snappy
   lifecycler:
     ring:
       kvstore:
         store: memberlist
       replication_factor: 1
-  max_transfer_retries: 0
   wal:
     dir: /var/loki/wal
-ingester_client:
-  grpc_client_config:
-    grpc_compression: gzip
+    flush_on_shutdown: true
 limits_config:
-  enforce_metric_name: false
+  allow_structured_metadata: true
   max_cache_freshness_per_query: 10m
+  query_timeout: 300s
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   split_queries_by_interval: 15m
+  volume_enabled: true
+  max_label_names_per_series: 30
 memberlist:
   join_members:
-    - loki-distributed-memberlist
+  - loki-distributed-memberlist
+pattern_ingester:
+  enabled: true
+querier:
+  max_concurrent: 4
 query_range:
   align_queries_with_step: true
   cache_results: true
-  max_retries: 5
   results_cache:
     cache:
       embedded_cache:
         enabled: true
         ttl: 24h
-ruler:
-  alertmanager_url: https://alertmanager.xx
-  external_url: https://alertmanager.xx
-  ring:
-    kvstore:
-      store: memberlist
-  rule_path: /tmp/loki/scratch
-  storage:
-    local:
-      directory: /etc/loki/rules
-    type: local
 runtime_config:
-  file: /var/loki-distributed-runtime/runtime.yaml
+  file: /etc/loki/runtime-config/runtime-config.yaml
 schema_config:
   configs:
-    - from: "2020-10-24"
-      index:
-        period: 24h
-        prefix: index_
-      object_store: s3
-      schema: v11
-      store: boltdb-shipper
+  - from: "2020-10-24"
+    index:
+      period: 24h
+      prefix: index_
+    object_store: s3
+    schema: v11
+    store: boltdb-shipper
 {{- if and (index .spec.distribution.modules.logging "loki") (index .spec.distribution.modules.logging.loki "tsdbStartDate") }}
-    - from: "{{ .spec.distribution.modules.logging.loki.tsdbStartDate }}" 
-      index:
-        period: 24h
-        prefix: index_
-      object_store: s3
-      schema: v13
-      store: tsdb
+  - from: "{{ .spec.distribution.modules.logging.loki.tsdbStartDate }}" 
+    index:
+      period: 24h
+      prefix: index_
+    object_store: s3
+    schema: v13
+    store: tsdb
 {{- end }}
 server:
+  grpc_listen_port: 9095
   http_listen_port: 3100
+  http_server_read_timeout: 600s
+  http_server_write_timeout: 600s
 storage_config:
-  aws:
-{{- if eq .spec.distribution.modules.logging.loki.backend "minio" }}
-    s3: http://{{ .spec.distribution.modules.logging.minio.rootUser.username }}:{{ .spec.distribution.modules.logging.minio.rootUser.password }}@minio-logging.logging.svc.cluster.local:9000/loki
-    s3forcepathstyle: true
-{{- end }}
-{{- if eq .spec.distribution.modules.logging.loki.backend "externalEndpoint" }}
-    s3: {{ ternary "http" "https" .spec.distribution.modules.logging.loki.externalEndpoint.insecure }}://{{ .spec.distribution.modules.logging.loki.externalEndpoint.accessKeyId }}:{{ .spec.distribution.modules.logging.loki.externalEndpoint.secretAccessKey }}@{{ .spec.distribution.modules.logging.loki.externalEndpoint.endpoint }}/{{ .spec.distribution.modules.logging.loki.externalEndpoint.bucketName }}
-    s3forcepathstyle: true
-{{- end }}
+  bloom_shipper:
+    working_directory: /var/loki/data/bloomshipper
   boltdb_shipper:
-    active_index_directory: /var/loki/index
-    cache_location: /var/loki/cache
-    cache_ttl: 24h
-    resync_interval: 5s
-    shared_store: s3
+    index_gateway_client:
+      server_address: dns+loki-distributed-index-gateway-headless.logging.svc.cluster.local:9095
+  hedging:
+    at: 250ms
+    max_per_second: 20
+    up_to: 3
   tsdb_shipper:
-    active_index_directory: /var/loki/index
-    cache_location: /var/loki/cache
-    cache_ttl: 24h
-    resync_interval: 5s
-    shared_store: s3
-  filesystem:
-    directory: /var/loki/chunks
+    index_gateway_client:
+      server_address: dns+loki-distributed-index-gateway-headless.logging.svc.cluster.local:9095
+tracing:
+  enabled: false
 table_manager:
   retention_deletes_enabled: false
   retention_period: 0s

--- a/templates/distribution/manifests/logging/patches/loki.yml.tpl
+++ b/templates/distribution/manifests/logging/patches/loki.yml.tpl
@@ -20,7 +20,7 @@ spec:
           {{ $package.resources | toYaml | indent 10 | trim }}
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: loki-distributed-compactor
   namespace: logging
@@ -68,6 +68,45 @@ spec:
     spec:
       containers:
       - name: query-frontend
+        resources:
+          {{ $package.resources | toYaml | indent 10 | trim }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loki-distributed-querier
+  namespace: logging
+spec:
+  template:
+    spec:
+      containers:
+      - name: querier
+        resources:
+          {{ $package.resources | toYaml | indent 10 | trim }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loki-distributed-query-scheduler
+  namespace: logging
+spec:
+  template:
+    spec:
+      containers:
+      - name: query-scheduler
+        resources:
+          {{ $package.resources | toYaml | indent 10 | trim }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: loki-distributed-index-gateway
+  namespace: logging
+spec:
+  template:
+    spec:
+      containers:
+      - name: index-gateway
         resources:
           {{ $package.resources | toYaml | indent 10 | trim }}
 {{- end }}

--- a/templates/distribution/manifests/logging/patches/minio.credentials.loki.env.tpl
+++ b/templates/distribution/manifests/logging/patches/minio.credentials.loki.env.tpl
@@ -1,0 +1,8 @@
+{{- if eq .spec.distribution.modules.logging.loki.backend "minio" }}
+MINIO_ACCESS_KEY={{ .spec.distribution.modules.logging.minio.rootUser.username }}
+MINIO_SECRET_KEY={{ .spec.distribution.modules.logging.minio.rootUser.password }}
+{{- end }}
+{{- if eq .spec.distribution.modules.logging.loki.backend "externalEndpoint" }}
+MINIO_ACCESS_KEY={{ .spec.distribution.modules.logging.loki.externalEndpoint.accessKeyId }}
+MINIO_SECRET_KEY={{ .spec.distribution.modules.logging.loki.externalEndpoint.secretAccessKey }}
+{{- end }}


### PR DESCRIPTION
### Summary 💡

This PR adds the changes needed to migrate to Loki version 3.4.2.

<!-- If this PR is related to changes produced in other repos, like a Module, please link them below. -->
Relates:
https://github.com/sighupio/module-logging/pull/181
https://github.com/sighupio/module-logging/pull/183

### Description 📝

- Renaming secrets and adding `minio-credentials-loki` in `templates/distribution/manifests/logging/kustomization.yaml.tpl`
- Change resource type and add new components (index-gateway, query-frontend) in `templates/distribution/manifests/logging/patches/infra-nodes.yml.tpl` and `templates/distribution/manifests/logging/patches/loki.yml.tpl` (in the latter the querier was missing and it has been added)
- Use new Loki config in `templates/distribution/manifests/logging/patches/loki-config.yaml.tpl`
- Add minio credentials template for Loki
- Minio/external storage credentials have been parametrized in the new configuration

### Breaking Changes 💔

- The new Loki configuration template is not compatible with the previous one
- Minio/external storage credentials have been parametrized and the new format is not compatible with the previous configuration.

### Tests performed 🧪

- [X] Tested the change with KFD version 1.31.0
- [X] Tested an upgrade from the previous version 2.9.10 (Logging Core Module 4.0.0)
- [X] Tested with a clean install on kind with Kubernetes v1.32.2
- [X] Tested with an upgrade with`furyctl` from KFD v1.31.0 to this version - K8S v1.32.2
