### PR TITLE
Fix etcd-backup while on EKS provider

### DIFF
--- a/templates/distribution/manifests/dr/resources/etcd-backup-pvc.yml.tpl
+++ b/templates/distribution/manifests/dr/resources/etcd-backup-pvc.yml.tpl
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+{{- if eq .spec.distribution.common.provider.type "none" }}
 {{- if eq .spec.distribution.modules.dr.etcdBackup.type "all" "pvc" }}
 {{- if not (index .spec.distribution.modules.dr.etcdBackup.pvc "name") }}
 ---
@@ -20,5 +21,6 @@ spec:
   resources:
     requests:
       storage: {{ .spec.distribution.modules.dr.etcdBackup.pvc.size }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/distribution/manifests/dr/secrets/rclone.conf.tpl
+++ b/templates/distribution/manifests/dr/secrets/rclone.conf.tpl
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+{{- if eq .spec.distribution.common.provider.type "none" }}
 {{- if eq .spec.distribution.modules.dr.etcdBackup.type "all" "s3" }}
 [s3]
 type = s3
@@ -9,4 +10,5 @@ access_key_id = {{ .spec.distribution.modules.dr.etcdBackup.s3.accessKeyId }}
 secret_access_key = {{ .spec.distribution.modules.dr.etcdBackup.s3.secretAccessKey }}
 endpoint = {{ ternary "http" "https" .spec.distribution.modules.dr.etcdBackup.s3.insecure }}://{{ .spec.distribution.modules.dr.etcdBackup.s3.endpoint }}
 force_path_style = true
-{{- end}}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
### Summary 💡
This PR fixes a small rendering problem found while testing EKS.

### Description 📝
During the distribution phase the EKS provider failed because it tried to render a file which contained invalid fields. This is fixed by avoiding to render the etcd-backup files when on EKS.

### Breaking Changes 💔
None.

### Tests performed 🧪
None.

### Future work 🔧
None.