### PR TITLE
Fix immutability on control planes

### DIFF
--- a/templates/preflight/onpremises/verify-playbook.yaml
+++ b/templates/preflight/onpremises/verify-playbook.yaml
@@ -11,9 +11,17 @@
         path: /etc/kubernetes/admin.conf
       register: admin_conf_stat
 
+    - name: Getting admin.conf kubeconfig
+      become: yes
+      fetch:
+        src: /etc/kubernetes/admin.conf
+        dest: "{{ kubernetes_kubeconfig_path }}/admin.conf"
+        flat: yes
+      when: admin_conf_stat.stat.exists
+            
     - name: Set fact if admin.conf exists
       set_fact:
-        admin_conf_exists: "{{"{{ admin_conf_stat.stat.exists }}"}}"
+        admin_conf_exists: "{{ admin_conf_stat.stat.exists }}"
       when: admin_conf_stat.stat.exists
 
 - name: Aggregate results and fetch admin.conf
@@ -25,8 +33,8 @@
 
     - name: Check if any master has admin.conf
       set_fact:
-        any_master_has_conf: "{{"{{ any_master_has_conf or hostvars[item].admin_conf_exists }}"}}"
-      loop: "{{"{{ groups['master'] }}"}}"
+        any_master_has_conf: "{{ any_master_has_conf or hostvars[item].admin_conf_exists }}"
+      loop: "{{ groups['master'] }}"
       when: hostvars[item].admin_conf_exists is defined
 
     - name: Fail if no master has admin.conf


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request.

By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull
request to the best possible team for review.

💡 **TIP**
Remember that you can always open a PR in draft status and fill all the information afterwards.

Opening a PR in draft allows other team members to know that you are working on this change, and let's you have a
place to track your work in progress.

When opening PRs in Draft, **don't assign reviewers until the PR is ready for review**.

Once you are confortable with the status of the PR and all the tests and CI is green, you can assign the reviewers to start the review process.
-->

### Summary 💡
This PR addresses a bug preventing control planes nodes array to be marked as immutable under the OnPremises provider. Control plane nodes were set as immutable in the 1.31.1 release cycle because we don't have any support to scale the etcd cluster with the number of control plane nodes. Moreover, the etcd cluster can potentially be placed on control plane nodes or set-up on separate machines, adding further cases to the etcd scaling support, which at the moment we don't support.

<!--
If there's an existing issue for your change, please link to it below inserting a link or the issue number.

If there's _not_ an existing issue, please open one first if the problem you are solving needs to be clearly identified,
for example is an error message that other users could get and google it.
-->
Closes: #360 

Refers:  https://github.com/sighupio/product-management/issues/651

### Description 📝
Immutable behaviour in the OnPremises provider is checked during the preflight phase, after having checked the availability of the hosts set in the `.spec.kubernetes.masters.hosts.*` keys in `furyctl.yaml`. The availability of the hosts is performed with an Ansible Playbook, called `verify-playbook.yaml`.

This playbook is used to both check the availability of the hosts and to get the kubeconfig necessary to talk with the cluster. It does so by accessing the `/etc/kubernetes/admin.conf` file from all hosts inside the `.spec.kubernetes.masters.hosts.*` key and copies the `admin.conf` in a local (to the machine running `furyctl`) directory. The surrounding logic about this playbook is the following: if, for any reason, the playbook fails, we mark the cluster as "pristine" and we proceed to install the cluster as if it's yet to be installed, bypassing the immutability checks, since this cluster is now treated as brand new.

So, if we installed the cluster the first time with `furyctl apply` and then proceeded to edit the `furyctl.yaml` adding a new master, and re-ran `furyctl apply`, `verify-playbook.yaml` fails (since the `master` hosts are now two, and one of them doesn't contain the `admin.conf` triggering a failure), marking the already installed cluster as "brand new", bypassing the immutability checks and triggering all the new installation ceremonies.

The fix is simple, and is to make it fail if and only if no host contains a `/etc/kubernetes/admin.conf` file. This makes the check works as intended and lets the immutability checks do their intended job.

### Breaking Changes 💔
Nothing.

### Tests performed 🧪
 - [x] Installed a cluster with only one control plane set, edited its `furyctl.yaml` file and retried `furyctl apply`. Expected output: *immutability check failed*. Actual result: as expected.

### Future work 🔧
Introduce etcd cluster scaling so that we can drop the immutability.