### PR TITLE
feat(KFDDistribution): add network policies for all SD components to KFDDistribution provider

### DIFF
--- a/docs/schemas/kfddistribution-kfd-v1alpha2.md
+++ b/docs/schemas/kfddistribution-kfd-v1alpha2.md
@@ -90,17 +90,24 @@ The name of the cluster. It will also be used as a prefix for all the other reso
 
 ### Properties
 
-| Property                                                        | Type     | Required |
-|:----------------------------------------------------------------|:---------|:---------|
-| [nodeSelector](#specdistributioncommonnodeselector)             | `object` | Optional |
-| [provider](#specdistributioncommonprovider)                     | `object` | Optional |
-| [registry](#specdistributioncommonregistry)                     | `string` | Optional |
-| [relativeVendorPath](#specdistributioncommonrelativevendorpath) | `string` | Optional |
-| [tolerations](#specdistributioncommontolerations)               | `array`  | Optional |
+| Property                                                                | Type      | Required |
+|:------------------------------------------------------------------------|:----------|:---------|
+| [networkPoliciesEnabled](#specdistributioncommonnetworkpoliciesenabled) | `boolean` | Optional |
+| [nodeSelector](#specdistributioncommonnodeselector)                     | `object`  | Optional |
+| [provider](#specdistributioncommonprovider)                             | `object`  | Optional |
+| [registry](#specdistributioncommonregistry)                             | `string`  | Optional |
+| [relativeVendorPath](#specdistributioncommonrelativevendorpath)         | `string`  | Optional |
+| [tolerations](#specdistributioncommontolerations)                       | `array`   | Optional |
 
 ### Description
 
 Common configuration for all the distribution modules.
+
+## .spec.distribution.common.networkPoliciesEnabled
+
+### Description
+
+EXPERIMENTAL FEATURE. This field defines whether Network Policies are provided for core modules.
 
 ## .spec.distribution.common.nodeSelector
 

--- a/pkg/apis/kfddistribution/v1alpha2/public/schema.go
+++ b/pkg/apis/kfddistribution/v1alpha2/public/schema.go
@@ -64,6 +64,10 @@ type SpecDistribution struct {
 
 // Common configuration for all the distribution modules.
 type SpecDistributionCommon struct {
+	// EXPERIMENTAL FEATURE. This field defines whether Network Policies are provided
+	// for core modules.
+	NetworkPoliciesEnabled *bool `json:"networkPoliciesEnabled,omitempty" yaml:"networkPoliciesEnabled,omitempty" mapstructure:"networkPoliciesEnabled,omitempty"`
+
 	// The node selector to use to place the pods for all the KFD modules. Follows
 	// Kubernetes selector format. Example: `node.kubernetes.io/role: infra`.
 	NodeSelector TypesKubeNodeSelector `json:"nodeSelector,omitempty" yaml:"nodeSelector,omitempty" mapstructure:"nodeSelector,omitempty"`

--- a/schemas/public/kfddistribution-kfd-v1alpha2.json
+++ b/schemas/public/kfddistribution-kfd-v1alpha2.json
@@ -159,6 +159,10 @@
         "registry": {
           "type": "string",
           "description": "URL of the registry where to pull images from for the Distribution phase. (Default is `registry.sighup.io/fury`).\n\nNOTE: If plugins are pulling from the default registry, the registry will be replaced for the plugin too."
+        },
+        "networkPoliciesEnabled": {
+          "type": "boolean",
+          "description": "EXPERIMENTAL FEATURE. This field defines whether Network Policies are provided for core modules."
         }
       }
     },

--- a/tests/e2e/kfddistribution-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml
+++ b/tests/e2e/kfddistribution-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml
@@ -13,8 +13,7 @@ spec:
   distribution:
     kubeconfig: "{env://KUBECONFIG}"
     # This common configuration will be applied to all the packages that will be installed in the cluster
-    common:
-      networkPoliciesEnabled: true
+    common: {}
     # This section contains all the configurations for all the KFD core modules
     modules:
       networking:

--- a/tests/e2e/kfddistribution-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml
+++ b/tests/e2e/kfddistribution-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml
@@ -13,7 +13,8 @@ spec:
   distribution:
     kubeconfig: "{env://KUBECONFIG}"
     # This common configuration will be applied to all the packages that will be installed in the cluster
-    common: {}
+    common:
+      networkPoliciesEnabled: true
     # This section contains all the configurations for all the KFD core modules
     modules:
       networking:

--- a/tests/e2e/kfddistribution-upgrades/manifests/furyctl-init-cluster-1.31.1.yaml
+++ b/tests/e2e/kfddistribution-upgrades/manifests/furyctl-init-cluster-1.31.1.yaml
@@ -13,7 +13,8 @@ spec:
   distribution:
     kubeconfig: "{env://KUBECONFIG}"
     # This common configuration will be applied to all the packages that will be installed in the cluster
-    common: {}
+    common:
+      networkPoliciesEnabled: true
     # This section contains all the configurations for all the KFD core modules
     modules:
       networking:

--- a/tests/e2e/kfddistribution/manifests/furyctl-10-migrate-from-none-to-safe-values.yaml
+++ b/tests/e2e/kfddistribution/manifests/furyctl-10-migrate-from-none-to-safe-values.yaml
@@ -13,7 +13,8 @@ spec:
   distribution:
     kubeconfig: "{env://KUBECONFIG}"
     # This common configuration will be applied to all the packages that will be installed in the cluster
-    common: {}
+    common:
+      networkPoliciesEnabled: true
     # This section contains all the configurations for all the KFD core modules
     modules:
       networking:

--- a/tests/e2e/kfddistribution/manifests/furyctl-11-migrate-from-kyverno-default-policies-to-disabled.yaml
+++ b/tests/e2e/kfddistribution/manifests/furyctl-11-migrate-from-kyverno-default-policies-to-disabled.yaml
@@ -13,7 +13,8 @@ spec:
   distribution:
     kubeconfig: "{env://KUBECONFIG}"
     # This common configuration will be applied to all the packages that will be installed in the cluster
-    common: {}
+    common:
+      networkPoliciesEnabled: true
     # This section contains all the configurations for all the KFD core modules
     modules:
       networking:

--- a/tests/e2e/kfddistribution/manifests/furyctl-12-migrate-from-alertmanagerconfigs-to-disabled.yaml
+++ b/tests/e2e/kfddistribution/manifests/furyctl-12-migrate-from-alertmanagerconfigs-to-disabled.yaml
@@ -13,7 +13,8 @@ spec:
   distribution:
     kubeconfig: "{env://KUBECONFIG}"
     # This common configuration will be applied to all the packages that will be installed in the cluster
-    common: {}
+    common:
+      networkPoliciesEnabled: true
     # This section contains all the configurations for all the KFD core modules
     modules:
       networking:

--- a/tests/e2e/kfddistribution/manifests/furyctl-2-migrate-from-tempo-to-none.yaml
+++ b/tests/e2e/kfddistribution/manifests/furyctl-2-migrate-from-tempo-to-none.yaml
@@ -13,7 +13,8 @@ spec:
   distribution:
     kubeconfig: "{env://KUBECONFIG}"
     # This common configuration will be applied to all the packages that will be installed in the cluster
-    common: {}
+    common:
+      networkPoliciesEnabled: true
     # This section contains all the configurations for all the KFD core modules
     modules:
       networking:

--- a/tests/e2e/kfddistribution/manifests/furyctl-3-migrate-from-kyverno-to-none.yaml
+++ b/tests/e2e/kfddistribution/manifests/furyctl-3-migrate-from-kyverno-to-none.yaml
@@ -13,7 +13,8 @@ spec:
   distribution:
     kubeconfig: "{env://KUBECONFIG}"
     # This common configuration will be applied to all the packages that will be installed in the cluster
-    common: {}
+    common:
+      networkPoliciesEnabled: true
     # This section contains all the configurations for all the KFD core modules
     modules:
       networking:

--- a/tests/e2e/kfddistribution/manifests/furyctl-4-migrate-from-velero-to-none.yaml
+++ b/tests/e2e/kfddistribution/manifests/furyctl-4-migrate-from-velero-to-none.yaml
@@ -13,7 +13,8 @@ spec:
   distribution:
     kubeconfig: "{env://KUBECONFIG}"
     # This common configuration will be applied to all the packages that will be installed in the cluster
-    common: {}
+    common:
+      networkPoliciesEnabled: true
     # This section contains all the configurations for all the KFD core modules
     modules:
       networking:

--- a/tests/e2e/kfddistribution/manifests/furyctl-5-migrate-from-loki-to-none.yaml
+++ b/tests/e2e/kfddistribution/manifests/furyctl-5-migrate-from-loki-to-none.yaml
@@ -13,7 +13,8 @@ spec:
   distribution:
     kubeconfig: "{env://KUBECONFIG}"
     # This common configuration will be applied to all the packages that will be installed in the cluster
-    common: {}
+    common:
+      networkPoliciesEnabled: true
     # This section contains all the configurations for all the KFD core modules
     modules:
       networking:

--- a/tests/e2e/kfddistribution/manifests/furyctl-6-migrate-from-mimir-to-none.yaml
+++ b/tests/e2e/kfddistribution/manifests/furyctl-6-migrate-from-mimir-to-none.yaml
@@ -13,7 +13,8 @@ spec:
   distribution:
     kubeconfig: "{env://KUBECONFIG}"
     # This common configuration will be applied to all the packages that will be installed in the cluster
-    common: {}
+    common:
+      networkPoliciesEnabled: true
     # This section contains all the configurations for all the KFD core modules
     modules:
       networking:

--- a/tests/e2e/kfddistribution/manifests/furyctl-7-migrate-from-basicAuth-to-sso.yaml
+++ b/tests/e2e/kfddistribution/manifests/furyctl-7-migrate-from-basicAuth-to-sso.yaml
@@ -13,7 +13,8 @@ spec:
   distribution:
     kubeconfig: "{env://KUBECONFIG}"
     # This common configuration will be applied to all the packages that will be installed in the cluster
-    common: {}
+    common:
+      networkPoliciesEnabled: true
     # This section contains all the configurations for all the KFD core modules
     modules:
       networking:

--- a/tests/e2e/kfddistribution/manifests/furyctl-8-migrate-from-sso-to-none.yaml
+++ b/tests/e2e/kfddistribution/manifests/furyctl-8-migrate-from-sso-to-none.yaml
@@ -13,7 +13,8 @@ spec:
   distribution:
     kubeconfig: "{env://KUBECONFIG}"
     # This common configuration will be applied to all the packages that will be installed in the cluster
-    common: {}
+    common:
+      networkPoliciesEnabled: true
     # This section contains all the configurations for all the KFD core modules
     modules:
       networking:

--- a/tests/e2e/kfddistribution/manifests/furyctl-9-migrate-from-nginx-to-none.yaml
+++ b/tests/e2e/kfddistribution/manifests/furyctl-9-migrate-from-nginx-to-none.yaml
@@ -13,7 +13,8 @@ spec:
   distribution:
     kubeconfig: "{env://KUBECONFIG}"
     # This common configuration will be applied to all the packages that will be installed in the cluster
-    common: {}
+    common:
+      networkPoliciesEnabled: true
     # This section contains all the configurations for all the KFD core modules
     modules:
       networking:

--- a/tests/e2e/kfddistribution/manifests/furyctl-cleanup-all.yaml
+++ b/tests/e2e/kfddistribution/manifests/furyctl-cleanup-all.yaml
@@ -13,7 +13,8 @@ spec:
   distribution:
     kubeconfig: "{env://KUBECONFIG}"
     # This common configuration will be applied to all the packages that will be installed in the cluster
-    common: {}
+    common:
+      networkPoliciesEnabled: true
     # This section contains all the configurations for all the KFD core modules
     modules:
       networking:

--- a/tests/e2e/kfddistribution/manifests/furyctl-init-cluster.yaml
+++ b/tests/e2e/kfddistribution/manifests/furyctl-init-cluster.yaml
@@ -13,7 +13,8 @@ spec:
   distribution:
     kubeconfig: "{env://KUBECONFIG}"
     # This common configuration will be applied to all the packages that will be installed in the cluster
-    common: {}
+    common:
+      networkPoliciesEnabled: true
     # This section contains all the configurations for all the KFD core modules
     modules:
       networking:


### PR DESCRIPTION
### Summary 💡

This PR adds Kubernetes Network Policies support to the KFDDistribution provider.

The `spec.distribution.common.networkPoliciesEnabled` field to allow the creation of Network Policies, already present in the OnPremises schema (see  [this](https://github.com/sighupio/distribution/pull/302) PR), was also added to KFDDistribution schema. By default the field's value is false, so you have to explicitly set it to true in order to enable it. 

Network Policies have been enabled for e2e tests of KFDDistribution provider.

Closes: [#639](https://github.com/sighupio/product-management/issues/639)

Relates: [#302](https://github.com/sighupio/distribution/pull/302)

### Description 📝

See above.

### Breaking Changes 💔

None.

### Tests performed 🧪

- [ ] Ran e2e [3087](https://ci.sighup.io/sighupio/distribution/3087) successfully.

### Future work 🔧

None.
