### PR TITLE
fix(templates): add condition for network policies in Ingress module

### DIFF
--- a/templates/distribution/manifests/ingress/kustomization.yaml.tpl
+++ b/templates/distribution/manifests/ingress/kustomization.yaml.tpl
@@ -24,7 +24,7 @@ resources:
 
 {{- end }}
 
-{{ if eq .spec.distribution.common.networkPoliciesEnabled true }}
+{{- if and (eq .spec.distribution.common.networkPoliciesEnabled true) (or (eq .spec.distribution.modules.ingress.nginx.tls.provider "certManager") (ne .spec.distribution.modules.ingress.nginx.type "none")) }}
   - policies
 {{- end }}
 


### PR DESCRIPTION
### Summary 💡

With this PR network policies for the Ingress module are included in the root `kustomization.yaml` only when at least one condition between `spec.distribution.modules.ingress.nginx.tls.provider: certManager` or `spec.distribution.modules.ingress.nginx.type != none` is met and `spec.distribution.common.networkPoliciesEnabled` is true.

Closes: [#365](https://github.com/sighupio/distribution/issues/365)

### Description 📝

With the migration from Kustomize v3 to v5, the behavior around empty `kustomization.yaml` files has changed.
In Kustomize v3, a file with an empty resources list was silently ignored, in Kustomize v5 the same file causes an error during the build.

To fix this, we now include the network policies only when network policies are enabled and at least one of the above conditions applies.

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] Tested the change with `spec.distribution.modules.ingress.nginx.tls.provider: certManager`
- [x] Tested the change with `spec.distribution.modules.ingress.nginx.tls.provider: secret`
- [x] Tested the change with `spec.distribution.modules.ingress.nginx.type: single`
- [x] Tested the change with `spec.distribution.modules.ingress.nginx.type: none`

### Future work 🔧

None.