### PR TITLE
feat(logging): add support for parametric logs retention in Loki

### DIFF
--- a/defaults/ekscluster-kfd-v1alpha2.yaml
+++ b/defaults/ekscluster-kfd-v1alpha2.yaml
@@ -113,6 +113,8 @@ data:
           secretAccessKey: example
           accessKeyId: example
           bucketName: lokibucket
+        # retentionPeriod can be set to 0s to disable retention
+        retentionPeriod: 720h # 30 days
       customOutputs: {}
     # monitoring module configuration
     monitoring:

--- a/defaults/kfddistribution-kfd-v1alpha2.yaml
+++ b/defaults/kfddistribution-kfd-v1alpha2.yaml
@@ -106,6 +106,8 @@ data:
           secretAccessKey: example
           accessKeyId: example
           bucketName: lokibucket
+        # retentionPeriod can be set to 0s to disable retention
+        retentionPeriod: 720h # 30 days
       customOutputs: {}
     # monitoring module configuration
     monitoring:

--- a/defaults/onpremises-kfd-v1alpha2.yaml
+++ b/defaults/onpremises-kfd-v1alpha2.yaml
@@ -106,6 +106,8 @@ data:
           secretAccessKey: example
           accessKeyId: example
           bucketName: lokibucket
+        # retentionPeriod can be set to 0s to disable retention
+        retentionPeriod: 720h # 30 days
       customOutputs: {}
     # monitoring module configuration
     monitoring:

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -13,9 +13,12 @@ The distribution is maintained with ❤️ by the team [SIGHUP by ReeVo](https:/
 ## Breaking changes 💔
 
 ## New features 🌟
+- [[#396](https://github.com/sighupio/distribution/pull/396)]: This PR adds the retention configurations to Loki in logging module. This is an optional field to define retention period for logs stored in Loki. If not set, the default value is 30 days. Users can set it to `0s` to disable retention.
+- [[#391](https://github.com/sighupio/distribution/pull/391)]: With this PR users can enable the installation of network policies that will restrict the traffic across all the infrastructural namespaces of SD (SIGHUP Distribution) to just the access needed for its proper functioning and denying the rest of it. This experimental feature is now available also in the KFDDistribution provider.
 
 ## Fixes 🐞
 - [[#387](https://github.com/sighupio/distribution/pull/387)]: This PR fixed an issue that prevented the control planes nodes array to be treated as immutable under the OnPremises provider. The number of control plane nodes was originally set as immutable in the 1.31.1 release cycle because there isn't any support to scale the etcd cluster with the number of control plane nodes in the SIGHUP Distribution yet. The issue allowed users to change the number of the control plane, even if it was explicitly marked as immutable.
+- [[#393](https://github.com/sighupio/distribution/pull/393)]: This PR fixes an issue present when users start the cluster with ingress type none, tls provider secret, and network policies disabled and try to enabled them afterwards.
 
 ### Security fixes
 

--- a/docs/schemas/ekscluster-kfd-v1alpha2.md
+++ b/docs/schemas/ekscluster-kfd-v1alpha2.md
@@ -2619,7 +2619,7 @@ The memory request for the Pod. Example: `500M`.
 
 ### Description
 
-Optional retention period for logs stored in Loki (default `720h`, 30 days). Setting it to `0s` disables retention.
+Optional retention period for logs stored in Loki (default `720h`, 30 days). Setting it to `0s` disables retention. Format must match: `[0-9]+(s|m|h|d|w|y)`.
 
 ## .spec.distribution.modules.logging.loki.tsdbStartDate
 

--- a/docs/schemas/ekscluster-kfd-v1alpha2.md
+++ b/docs/schemas/ekscluster-kfd-v1alpha2.md
@@ -2496,6 +2496,7 @@ This value defines where the output from the `systemdEtcd` Flow will be sent. Th
 | [backend](#specdistributionmoduleslogginglokibackend)                   | `string` | Optional |
 | [externalEndpoint](#specdistributionmoduleslogginglokiexternalendpoint) | `object` | Optional |
 | [resources](#specdistributionmoduleslogginglokiresources)               | `object` | Optional |
+| [retentionPeriod](#specdistributionmoduleslogginglokiretentionperiod)   | `string` | Optional |
 | [tsdbStartDate](#specdistributionmoduleslogginglokitsdbstartdate)       | `string` | Required |
 
 ### Description
@@ -2613,6 +2614,12 @@ The CPU request for the Pod, in cores. Example: `500m`.
 ### Description
 
 The memory request for the Pod. Example: `500M`.
+
+## .spec.distribution.modules.logging.loki.retentionPeriod
+
+### Description
+
+Optional retention period for logs stored in Loki (default `720h`, 30 days). Setting it to `0s` disables retention.
 
 ## .spec.distribution.modules.logging.loki.tsdbStartDate
 

--- a/docs/schemas/kfddistribution-kfd-v1alpha2.md
+++ b/docs/schemas/kfddistribution-kfd-v1alpha2.md
@@ -1990,6 +1990,7 @@ This value defines where the output from the `systemdEtcd` Flow will be sent. Th
 | [backend](#specdistributionmoduleslogginglokibackend)                   | `string` | Optional |
 | [externalEndpoint](#specdistributionmoduleslogginglokiexternalendpoint) | `object` | Optional |
 | [resources](#specdistributionmoduleslogginglokiresources)               | `object` | Optional |
+| [retentionPeriod](#specdistributionmoduleslogginglokiretentionperiod)   | `string` | Optional |
 | [tsdbStartDate](#specdistributionmoduleslogginglokitsdbstartdate)       | `string` | Required |
 
 ### Description
@@ -2107,6 +2108,12 @@ The CPU request for the Pod, in cores. Example: `500m`.
 ### Description
 
 The memory request for the Pod. Example: `500M`.
+
+## .spec.distribution.modules.logging.loki.retentionPeriod
+
+### Description
+
+Optional retention period for logs stored in Loki (default `720h`, 30 days). Setting it to `0s` disables retention.
 
 ## .spec.distribution.modules.logging.loki.tsdbStartDate
 

--- a/docs/schemas/kfddistribution-kfd-v1alpha2.md
+++ b/docs/schemas/kfddistribution-kfd-v1alpha2.md
@@ -2113,7 +2113,7 @@ The memory request for the Pod. Example: `500M`.
 
 ### Description
 
-Optional retention period for logs stored in Loki (default `720h`, 30 days). Setting it to `0s` disables retention.
+Optional retention period for logs stored in Loki (default `720h`, 30 days). Setting it to `0s` disables retention. Format must match: `[0-9]+(s|m|h|d|w|y)`.
 
 ## .spec.distribution.modules.logging.loki.tsdbStartDate
 

--- a/docs/schemas/onpremises-kfd-v1alpha2.md
+++ b/docs/schemas/onpremises-kfd-v1alpha2.md
@@ -2267,6 +2267,7 @@ This value defines where the output from the `systemdEtcd` Flow will be sent. Th
 | [backend](#specdistributionmoduleslogginglokibackend)                   | `string` | Optional |
 | [externalEndpoint](#specdistributionmoduleslogginglokiexternalendpoint) | `object` | Optional |
 | [resources](#specdistributionmoduleslogginglokiresources)               | `object` | Optional |
+| [retentionPeriod](#specdistributionmoduleslogginglokiretentionperiod)   | `string` | Optional |
 | [tsdbStartDate](#specdistributionmoduleslogginglokitsdbstartdate)       | `string` | Required |
 
 ### Description
@@ -2384,6 +2385,12 @@ The CPU request for the Pod, in cores. Example: `500m`.
 ### Description
 
 The memory request for the Pod. Example: `500M`.
+
+## .spec.distribution.modules.logging.loki.retentionPeriod
+
+### Description
+
+Optional retention period for logs stored in Loki (default `720h`, 30 days). Setting it to `0s` disables retention.
 
 ## .spec.distribution.modules.logging.loki.tsdbStartDate
 

--- a/docs/schemas/onpremises-kfd-v1alpha2.md
+++ b/docs/schemas/onpremises-kfd-v1alpha2.md
@@ -2390,7 +2390,7 @@ The memory request for the Pod. Example: `500M`.
 
 ### Description
 
-Optional retention period for logs stored in Loki (default `720h`, 30 days). Setting it to `0s` disables retention.
+Optional retention period for logs stored in Loki (default `720h`, 30 days). Setting it to `0s` disables retention. Format must match: `[0-9]+(s|m|h|d|w|y)`.
 
 ## .spec.distribution.modules.logging.loki.tsdbStartDate
 

--- a/pkg/apis/ekscluster/v1alpha2/private/schema.go
+++ b/pkg/apis/ekscluster/v1alpha2/private/schema.go
@@ -1850,7 +1850,8 @@ type SpecDistributionModulesLoggingLoki struct {
 	Resources *TypesKubeResources `json:"resources,omitempty" yaml:"resources,omitempty" mapstructure:"resources,omitempty"`
 
 	// Optional retention period for logs stored in Loki (default `720h`, 30 days).
-	// Setting it to `0s` disables retention.
+	// Setting it to `0s` disables retention. Format must match:
+	// `[0-9]+(s|m|h|d|w|y)`.
 	RetentionPeriod *string `json:"retentionPeriod,omitempty" yaml:"retentionPeriod,omitempty" mapstructure:"retentionPeriod,omitempty"`
 
 	// Starting from versions 1.28.4, 1.29.5 and 1.30.0 of SIGHUP Distribution, Loki

--- a/pkg/apis/ekscluster/v1alpha2/private/schema.go
+++ b/pkg/apis/ekscluster/v1alpha2/private/schema.go
@@ -1849,6 +1849,10 @@ type SpecDistributionModulesLoggingLoki struct {
 	// Resources corresponds to the JSON schema field "resources".
 	Resources *TypesKubeResources `json:"resources,omitempty" yaml:"resources,omitempty" mapstructure:"resources,omitempty"`
 
+	// Optional retention period for logs stored in Loki (default `720h`, 30 days).
+	// Setting it to `0s` disables retention.
+	RetentionPeriod *string `json:"retentionPeriod,omitempty" yaml:"retentionPeriod,omitempty" mapstructure:"retentionPeriod,omitempty"`
+
 	// Starting from versions 1.28.4, 1.29.5 and 1.30.0 of SIGHUP Distribution, Loki
 	// changed the time series database from BoltDB to TSDB and the schema that it
 	// uses to store the logs from v11 to v13.

--- a/pkg/apis/ekscluster/v1alpha2/public/schema.go
+++ b/pkg/apis/ekscluster/v1alpha2/public/schema.go
@@ -964,6 +964,10 @@ type SpecDistributionModulesLoggingLoki struct {
 	// Resources corresponds to the JSON schema field "resources".
 	Resources *TypesKubeResources `json:"resources,omitempty" yaml:"resources,omitempty" mapstructure:"resources,omitempty"`
 
+	// Optional retention period for logs stored in Loki (default `720h`, 30 days).
+	// Setting it to `0s` disables retention.
+	RetentionPeriod *string `json:"retentionPeriod,omitempty" yaml:"retentionPeriod,omitempty" mapstructure:"retentionPeriod,omitempty"`
+
 	// Starting from versions 1.28.4, 1.29.5 and 1.30.0 of SIGHUP Distribution, Loki
 	// changed the time series database from BoltDB to TSDB and the schema that it
 	// uses to store the logs from v11 to v13.

--- a/pkg/apis/ekscluster/v1alpha2/public/schema.go
+++ b/pkg/apis/ekscluster/v1alpha2/public/schema.go
@@ -965,7 +965,8 @@ type SpecDistributionModulesLoggingLoki struct {
 	Resources *TypesKubeResources `json:"resources,omitempty" yaml:"resources,omitempty" mapstructure:"resources,omitempty"`
 
 	// Optional retention period for logs stored in Loki (default `720h`, 30 days).
-	// Setting it to `0s` disables retention.
+	// Setting it to `0s` disables retention. Format must match:
+	// `[0-9]+(s|m|h|d|w|y)`.
 	RetentionPeriod *string `json:"retentionPeriod,omitempty" yaml:"retentionPeriod,omitempty" mapstructure:"retentionPeriod,omitempty"`
 
 	// Starting from versions 1.28.4, 1.29.5 and 1.30.0 of SIGHUP Distribution, Loki

--- a/pkg/apis/kfddistribution/v1alpha2/public/schema.go
+++ b/pkg/apis/kfddistribution/v1alpha2/public/schema.go
@@ -908,7 +908,8 @@ type SpecDistributionModulesLoggingLoki struct {
 	Resources *TypesKubeResources `json:"resources,omitempty" yaml:"resources,omitempty" mapstructure:"resources,omitempty"`
 
 	// Optional retention period for logs stored in Loki (default `720h`, 30 days).
-	// Setting it to `0s` disables retention.
+	// Setting it to `0s` disables retention. Format must match:
+	// `[0-9]+(s|m|h|d|w|y)`.
 	RetentionPeriod *string `json:"retentionPeriod,omitempty" yaml:"retentionPeriod,omitempty" mapstructure:"retentionPeriod,omitempty"`
 
 	// Starting from versions 1.28.4, 1.29.5 and 1.30.0 of SIGHUP Distribution, Loki

--- a/pkg/apis/kfddistribution/v1alpha2/public/schema.go
+++ b/pkg/apis/kfddistribution/v1alpha2/public/schema.go
@@ -907,6 +907,10 @@ type SpecDistributionModulesLoggingLoki struct {
 	// Resources corresponds to the JSON schema field "resources".
 	Resources *TypesKubeResources `json:"resources,omitempty" yaml:"resources,omitempty" mapstructure:"resources,omitempty"`
 
+	// Optional retention period for logs stored in Loki (default `720h`, 30 days).
+	// Setting it to `0s` disables retention.
+	RetentionPeriod *string `json:"retentionPeriod,omitempty" yaml:"retentionPeriod,omitempty" mapstructure:"retentionPeriod,omitempty"`
+
 	// Starting from versions 1.28.4, 1.29.5 and 1.30.0 of SIGHUP Distribution, Loki
 	// changed the time series database from BoltDB to TSDB and the schema that it
 	// uses to store the logs from v11 to v13.

--- a/pkg/apis/onpremises/v1alpha2/public/schema.go
+++ b/pkg/apis/onpremises/v1alpha2/public/schema.go
@@ -1059,7 +1059,8 @@ type SpecDistributionModulesLoggingLoki struct {
 	Resources *TypesKubeResources `json:"resources,omitempty" yaml:"resources,omitempty" mapstructure:"resources,omitempty"`
 
 	// Optional retention period for logs stored in Loki (default `720h`, 30 days).
-	// Setting it to `0s` disables retention.
+	// Setting it to `0s` disables retention. Format must match:
+	// `[0-9]+(s|m|h|d|w|y)`.
 	RetentionPeriod *string `json:"retentionPeriod,omitempty" yaml:"retentionPeriod,omitempty" mapstructure:"retentionPeriod,omitempty"`
 
 	// Starting from versions 1.28.4, 1.29.5 and 1.30.0 of SIGHUP Distribution, Loki

--- a/pkg/apis/onpremises/v1alpha2/public/schema.go
+++ b/pkg/apis/onpremises/v1alpha2/public/schema.go
@@ -1058,6 +1058,10 @@ type SpecDistributionModulesLoggingLoki struct {
 	// Resources corresponds to the JSON schema field "resources".
 	Resources *TypesKubeResources `json:"resources,omitempty" yaml:"resources,omitempty" mapstructure:"resources,omitempty"`
 
+	// Optional retention period for logs stored in Loki (default `720h`, 30 days).
+	// Setting it to `0s` disables retention.
+	RetentionPeriod *string `json:"retentionPeriod,omitempty" yaml:"retentionPeriod,omitempty" mapstructure:"retentionPeriod,omitempty"`
+
 	// Starting from versions 1.28.4, 1.29.5 and 1.30.0 of SIGHUP Distribution, Loki
 	// changed the time series database from BoltDB to TSDB and the schema that it
 	// uses to store the logs from v11 to v13.

--- a/schemas/private/ekscluster-kfd-v1alpha2.json
+++ b/schemas/private/ekscluster-kfd-v1alpha2.json
@@ -1760,6 +1760,10 @@
           "format": "date",
           "description": "Starting from versions 1.28.4, 1.29.5 and 1.30.0 of SIGHUP Distribution, Loki changed the time series database from BoltDB to TSDB and the schema that it uses to store the logs from v11 to v13.\n\nThe value of this field will determine the date when Loki will start writing using the new TSDB and the schema v13, always at midnight UTC. The old BoltDB and schema will be kept until all the logs expire for reading purposes.\n\nFrom versions 1.29.7, 1.30.2 and 1.31.1 of the Distribution, this field will be immutable once set and its value should be a date before upgrading to one of these versions or creating the cluster, Loki does not support writing BoltDB and schema v11 anymore.\n\nValue must be a string in `ISO 8601` date format (`yyyy-mm-dd`). Example: `2024-11-18`."
         },
+        "retentionPeriod": {
+          "type": "string",
+          "description": "Optional retention period for logs stored in Loki (default `720h`, 30 days). Setting it to `0s` disables retention."
+        },
         "resources": {
           "$ref": "#/$defs/Types.KubeResources"
         }

--- a/schemas/private/ekscluster-kfd-v1alpha2.json
+++ b/schemas/private/ekscluster-kfd-v1alpha2.json
@@ -1762,7 +1762,7 @@
         },
         "retentionPeriod": {
           "type": "string",
-          "description": "Optional retention period for logs stored in Loki (default `720h`, 30 days). Setting it to `0s` disables retention."
+          "description": "Optional retention period for logs stored in Loki (default `720h`, 30 days). Setting it to `0s` disables retention. Format must match: `[0-9]+(s|m|h|d|w|y)`."
         },
         "resources": {
           "$ref": "#/$defs/Types.KubeResources"

--- a/schemas/public/ekscluster-kfd-v1alpha2.json
+++ b/schemas/public/ekscluster-kfd-v1alpha2.json
@@ -1747,6 +1747,10 @@
           "format": "date",
           "description": "Starting from versions 1.28.4, 1.29.5 and 1.30.0 of SIGHUP Distribution, Loki changed the time series database from BoltDB to TSDB and the schema that it uses to store the logs from v11 to v13.\n\nThe value of this field will determine the date when Loki will start writing using the new TSDB and the schema v13, always at midnight UTC. The old BoltDB and schema will be kept until all the logs expire for reading purposes.\n\nFrom versions 1.29.7, 1.30.2 and 1.31.1 of the Distribution, this field will be immutable once set and its value should be a date before upgrading to one of these versions or creating the cluster, Loki does not support writing BoltDB and schema v11 anymore.\n\nValue must be a string in `ISO 8601` date format (`yyyy-mm-dd`). Example: `2024-11-18`."
         },
+        "retentionPeriod": {
+          "type": "string",
+          "description": "Optional retention period for logs stored in Loki (default `720h`, 30 days). Setting it to `0s` disables retention."
+        },
         "resources": {
           "$ref": "#/$defs/Types.KubeResources"
         }

--- a/schemas/public/ekscluster-kfd-v1alpha2.json
+++ b/schemas/public/ekscluster-kfd-v1alpha2.json
@@ -1749,7 +1749,7 @@
         },
         "retentionPeriod": {
           "type": "string",
-          "description": "Optional retention period for logs stored in Loki (default `720h`, 30 days). Setting it to `0s` disables retention."
+          "description": "Optional retention period for logs stored in Loki (default `720h`, 30 days). Setting it to `0s` disables retention. Format must match: `[0-9]+(s|m|h|d|w|y)`."
         },
         "resources": {
           "$ref": "#/$defs/Types.KubeResources"

--- a/schemas/public/kfddistribution-kfd-v1alpha2.json
+++ b/schemas/public/kfddistribution-kfd-v1alpha2.json
@@ -639,7 +639,7 @@
         },
         "retentionPeriod": {
           "type": "string",
-          "description": "Optional retention period for logs stored in Loki (default `720h`, 30 days). Setting it to `0s` disables retention."
+          "description": "Optional retention period for logs stored in Loki (default `720h`, 30 days). Setting it to `0s` disables retention. Format must match: `[0-9]+(s|m|h|d|w|y)`."
         },
         "resources": {
           "$ref": "#/$defs/Types.KubeResources"

--- a/schemas/public/kfddistribution-kfd-v1alpha2.json
+++ b/schemas/public/kfddistribution-kfd-v1alpha2.json
@@ -637,6 +637,10 @@
           "format": "date",
           "description": "Starting from versions 1.28.4, 1.29.5 and 1.30.0 of SIGHUP Distribution, Loki changed the time series database from BoltDB to TSDB and the schema that it uses to store the logs from v11 to v13.\n\nThe value of this field will determine the date when Loki will start writing using the new TSDB and the schema v13, always at midnight UTC. The old BoltDB and schema will be kept until all the logs expire for reading purposes.\n\nFrom versions 1.29.7, 1.30.2 and 1.31.1 of the Distribution, this field will be immutable once set and its value should be a date before upgrading to one of these versions or creating the cluster, Loki does not support writing BoltDB and schema v11 anymore.\n\nValue must be a string in `ISO 8601` date format (`yyyy-mm-dd`). Example: `2024-11-18`."
         },
+        "retentionPeriod": {
+          "type": "string",
+          "description": "Optional retention period for logs stored in Loki (default `720h`, 30 days). Setting it to `0s` disables retention."
+        },
         "resources": {
           "$ref": "#/$defs/Types.KubeResources"
         }

--- a/schemas/public/onpremises-kfd-v1alpha2.json
+++ b/schemas/public/onpremises-kfd-v1alpha2.json
@@ -1284,7 +1284,7 @@
         },
         "retentionPeriod": {
           "type": "string",
-          "description": "Optional retention period for logs stored in Loki (default `720h`, 30 days). Setting it to `0s` disables retention."
+          "description": "Optional retention period for logs stored in Loki (default `720h`, 30 days). Setting it to `0s` disables retention. Format must match: `[0-9]+(s|m|h|d|w|y)`."
         },
         "resources": {
           "$ref": "#/$defs/Types.KubeResources"

--- a/schemas/public/onpremises-kfd-v1alpha2.json
+++ b/schemas/public/onpremises-kfd-v1alpha2.json
@@ -1282,6 +1282,10 @@
           "format": "date",
           "description": "Starting from versions 1.28.4, 1.29.5 and 1.30.0 of SIGHUP Distribution, Loki changed the time series database from BoltDB to TSDB and the schema that it uses to store the logs from v11 to v13.\n\nThe value of this field will determine the date when Loki will start writing using the new TSDB and the schema v13, always at midnight UTC. The old BoltDB and schema will be kept until all the logs expire for reading purposes.\n\nFrom versions 1.29.7, 1.30.2 and 1.31.1 of the Distribution, this field will be immutable once set and its value should be a date before upgrading to one of these versions or creating the cluster, Loki does not support writing BoltDB and schema v11 anymore.\n\nValue must be a string in `ISO 8601` date format (`yyyy-mm-dd`). Example: `2024-11-18`."
         },
+        "retentionPeriod": {
+          "type": "string",
+          "description": "Optional retention period for logs stored in Loki (default `720h`, 30 days). Setting it to `0s` disables retention."
+        },
         "resources": {
           "$ref": "#/$defs/Types.KubeResources"
         }

--- a/templates/distribution/manifests/logging/patches/loki-config.yaml.tpl
+++ b/templates/distribution/manifests/logging/patches/loki-config.yaml.tpl
@@ -71,6 +71,7 @@ limits_config:
   split_queries_by_interval: 15m
   volume_enabled: true
   max_label_names_per_series: 30
+  retention_period: {{ .spec.distribution.modules.logging.loki.retentionPeriod }}
 memberlist:
   join_members:
   - loki-distributed-memberlist
@@ -132,8 +133,11 @@ storage_config:
     resync_interval: 5s
     index_gateway_client:
       server_address: dns+loki-distributed-index-gateway-headless.logging.svc.cluster.local:9095
+compactor:
+  working_directory: /var/loki/compactor
+  retention_enabled: {{ ne .spec.distribution.modules.logging.loki.retentionPeriod "0s" }}
+  retention_delete_delay: 2h
+  retention_delete_worker_count: 150
+  delete_request_store: s3
 tracing:
   enabled: false
-table_manager:
-  retention_deletes_enabled: false
-  retention_period: 0s


### PR DESCRIPTION
### Summary 💡

This PR adds support for logs retention in the Loki configuration using the compactor component, as specified in the Loki [official documentation](https://grafana.com/docs/loki/latest/operations/storage/retention/). This implementation follows the recommended approach for TSDB-based storage.

Closes: [https://github.com/sighupio/module-logging/issues/177](https://github.com/sighupio/module-logging/issues/177)

### Description 📝

The change includes:

- Support for global retention via the `retention_period` setting under `limits_config`
- Removal of `table_manager` (deprecated) configuration block
- Usage of the existing `persistentvolumeclaim/data-loki-distributed-compactor` as the working directory for the compactor

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] Tested the addition of the retention with SD version 1.31.1
- [x] Tested the change period with SD version 1.31.1
- [x] Tested the disabling of the retention with SD version 1.31.1

### Future work 🔧

None.
