### PR TITLE
feat: embedded docs

### DIFF
--- a/defaults/onpremises-kfd-v1alpha2.yaml
+++ b/defaults/onpremises-kfd-v1alpha2.yaml
@@ -18,6 +18,13 @@ data:
     networkPoliciesEnabled: false
   # the module section will be used to fine tune each module behaviour and configuration
   modules:
+    docs:
+      enabled: true
+      overrides:
+        ingresses:
+          docs:
+            host: ""
+            ingressClass: ""
     # ingress module configuration
     ingress:
       overrides:

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -14,6 +14,16 @@ The distribution is maintained with ❤️ by the team [SIGHUP by ReeVo](https:/
 
 ## New features 🌟
 
+- [[#XXX](https://github.com/sighupio/distribution/pull/XXX)] **Embedded Docs site**: the distribution now includes an embedded version of the docs site with the documentation for the SD version. The docs will be deployed by default and an (unprotected) ingress will be automatically created. You can disable and / or override some values with the new configuration key, for example:
+
+```yaml
+spec:
+  distribution:
+    modules:
+      docs:
+        enabled: false # disable embedded Docs
+```
+
 ## Fixes 🐞
 - [[#387](https://github.com/sighupio/distribution/pull/387)]: This PR fixed an issue that prevented the control planes nodes array to be treated as immutable under the OnPremises provider. The number of control plane nodes was originally set as immutable in the 1.31.1 release cycle because there isn't any support to scale the etcd cluster with the number of control plane nodes in the SIGHUP Distribution yet. The issue allowed users to change the number of the control plane, even if it was explicitly marked as immutable.
 

--- a/schemas/public/onpremises-kfd-v1alpha2.json
+++ b/schemas/public/onpremises-kfd-v1alpha2.json
@@ -834,6 +834,9 @@
         "dr": {
           "$ref": "#/$defs/Spec.Distribution.Modules.Dr"
         },
+        "docs": {
+          "$ref": "#/$defs/Spec.Distribution.Modules.Docs"
+        },
         "ingress": {
           "$ref": "#/$defs/Spec.Distribution.Modules.Ingress"
         },
@@ -859,6 +862,46 @@
         "logging",
         "policy"
       ]
+    },
+    "Spec.Distribution.Modules.Docs": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "overrides": {
+          "$ref": "#/$defs/Spec.Distribution.Modules.Docs.Overrides"
+        },
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "When enabled, the docs site will be included in the distribution and available at `docs.<baseDomain>`."
+        }
+      }
+    },
+    "Spec.Distribution.Modules.Docs.Overrides": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Override the common configuration with a particular configuration for the Docs module.",
+      "properties": {
+        "ingresses": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "docs": {
+              "$ref": "#/$defs/Types.FuryModuleOverridesIngress"
+            }
+          }        },
+        "nodeSelector": {
+          "$ref": "#/$defs/Types.KubeNodeSelector",
+          "description": "Set to override the node selector used to place the pods of the Ingress module."
+        },
+        "tolerations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Types.KubeToleration"
+          },
+          "description": "Set to override the tolerations that will be added to the pods of the Ingress module."
+        }
+      }
     },
     "Spec.Distribution.Modules.Ingress": {
       "type": "object",

--- a/templates/distribution/_helpers.tpl
+++ b/templates/distribution/_helpers.tpl
@@ -224,3 +224,7 @@ cert-manager.io/cluster-issuer: {{ .spec.distribution.modules.ingress.certManage
 {{ define "hubbleUrl" }}
   {{- template "ingressHost" (dict "module" "networking" "package" "hubble" "prefix" "hubble." "spec" .) -}}
 {{ end }}
+
+{{ define "docsUrl" }}
+  {{- template "ingressHost" (dict "module" "docs" "package" "docs" "prefix" "docs." "spec" .) -}}
+{{ end }}

--- a/templates/distribution/manifests/docs/deployment.yaml.tpl
+++ b/templates/distribution/manifests/docs/deployment.yaml.tpl
@@ -1,0 +1,52 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sd-docs
+  labels:
+    app.kubernetes.io/name: docs
+    app.kubernetes.io/version: "{{ .spec.distributionVersion }}"
+    app.kubernetes.io/part-of: sighup-distribution
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: docs
+      app.kubernetes.io/version: "{{ .spec.distributionVersion }}"
+      app.kubernetes.io/part-of: sighup-distribution
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: docs
+        app.kubernetes.io/version: "{{ .spec.distributionVersion }}"
+        app.kubernetes.io/part-of: sighup-distribution
+    spec:
+      tolerations:
+        {{ template "tolerations" dict "module" "docs" "package" "docs" "spec" .spec }}
+      nodeSelector:
+        {{ template "nodeSelector" dict "module" "docs" "package" "docs" "spec" .spec }}
+      containers:
+        - name: docs
+          image: registry.sighup.io/fury/docs:{{ .spec.distributionVersion | trimPrefix "v" }}-single
+          ports:
+            - name: http
+              containerPort: 8080
+          securityContext:
+            privileged: false
+            runAsNonRoot: true
+            runAsUser: 101
+            runAsGroup: 101
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/templates/distribution/manifests/docs/ingress.yaml.tpl
+++ b/templates/distribution/manifests/docs/ingress.yaml.tpl
@@ -1,0 +1,30 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sd-docs
+  labels:
+    app.kubernetes.io/name: docs
+    app.kubernetes.io/version: "{{ .spec.distributionVersion }}"
+    app.kubernetes.io/part-of: sighup-distribution
+  annotations:
+    cluster.kfd.sighup.io/useful-link.url: https://{{ template "docsUrl" .spec }}
+    cluster.kfd.sighup.io/useful-link.name: "SD Documentation"
+    forecastle.stakater.com/expose: "true"
+    forecastle.stakater.com/appName: "SIGHUP Distribution Documentation"
+    forecastle.stakater.com/icon: "https://raw.githubusercontent.com/sighupio/distribution/refs/heads/main/docs/assets/black-logo.png"
+    {{ template "certManagerClusterIssuer" . }}
+spec:
+  ingressClassName:  {{ template "ingressClass" (dict "module" "docs" "package" "docs" "type" "internal" "spec" .spec) }}
+  rules:
+    - host: {{ template "docsUrl" .spec }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: sd-docs
+                port:
+                  name: http
+{{- template "ingressTls" (dict "module" "docs" "package" "docs" "prefix" "docs." "spec" .spec) }}

--- a/templates/distribution/manifests/docs/kustomization.yaml.tpl
+++ b/templates/distribution/manifests/docs/kustomization.yaml.tpl
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: sd-docs
+resources:
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml
+  {{- if ne .spec.distribution.modules.ingress.nginx.type "none" }}
+  - ingress.yaml
+  {{- end }}

--- a/templates/distribution/manifests/docs/namespace.yaml.tpl
+++ b/templates/distribution/manifests/docs/namespace.yaml.tpl
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sd-docs
+  labels:
+    app.kubernetes.io/name: docs
+    app.kubernetes.io/version: "{{ .spec.distributionVersion }}"
+    app.kubernetes.io/part-of: sighup-distribution

--- a/templates/distribution/manifests/docs/service.yaml.tpl
+++ b/templates/distribution/manifests/docs/service.yaml.tpl
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sd-docs
+  labels:
+    app.kubernetes.io/name: docs
+    app.kubernetes.io/version: "{{ .spec.distributionVersion }}"
+    app.kubernetes.io/part-of: sighup-distribution
+spec:
+  selector:
+    app.kubernetes.io/name: docs
+    app.kubernetes.io/version: "{{ .spec.distributionVersion }}"
+    app.kubernetes.io/part-of: sighup-distribution
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/templates/distribution/manifests/kustomization.yaml.tpl
+++ b/templates/distribution/manifests/kustomization.yaml.tpl
@@ -35,6 +35,9 @@ resources:
 {{- if and (eq .spec.distribution.modules.tracing.type "tempo") (.checks.storageClassAvailable) }}
   - tracing
 {{- end }}
+{{- if .spec.distribution.modules.docs.enabled }}
+  - docs
+{{- end }}
 
 {{- if .spec.distribution.customPatches.patchesStrategicMerge }}
 patchesStrategicMerge:


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request.

By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull
request to the best possible team for review.

💡 **TIP**
Remember that you can always open a PR in draft status and fill all the information afterwards.

Opening a PR in draft allows other team members to know that you are working on this change, and let's you have a
place to track your work in progress.

When opening PRs in Draft, **don't assign reviewers until the PR is ready for review**.

Once you are confortable with the status of the PR and all the tests and CI is green, you can assign the reviewers to start the review process.
-->

### Summary 💡

- Add docs pseudo module manifests
- Add docs pseudo module to on-premises schema and set default values

Relates:
- https://github.com/sighupio/product-management/issues/646 (private)
- https://github.com/sighupio/docs/pull/158 (private)

> [!NOTE]
> Opening the PR as draft until I add the missing providers.

### Description 📝

This PR adds a new `docs` "pseudo-module" (all the manifests live here in the distribution repo, there is no actual docs module). This pseudo-module deploys a special build of the docs site, with the documentation for _only_ the version of SD that you are installing.

This version of the docs site is build in our docs repository and has working local search.

The docs site will be accessible at an automatically created ingress `docs.<base domain>`. The ingress will not be under SSO even if enabled, documentation is publicly accessible anyway.

There are some overrides that the user can perform, as per usual, like the ingress host, ingress class and nodeSelector and Tolerations.

**Open to discussion**:
1. is it a `docs` pseudo-module the right place for this? Maybe we could have a `utils` module (as we have discussed in the past) and this be a part of it?
2. if enable the docs by default or not, it could be a problem for our testing phases because the site container images won't be available until after we do the release. So we will need to have that into consideration. We can always disable the docs in the e2e or use a patch to change the image tag to an existing one.

### Breaking Changes 💔

None

### Tests performed 🧪

> [!NOTE]
> All tests have been performed on an on-premises cluster running SD 1.31.1.

- [x] Enabled / Disabled the docs and verified that the resources are created / deleted.
- [x] Tested with single ingress
- [x] Tested with dual ingress
- [x] Tested with ingress disabled (none):the Ingress resource is not created and the rest of the resources are deployed as expected.
- [x] Tested overriding the ingress host
- [x] Tested common tolerations and selectors are properly applied.

### Future work 🔧

<!--
If there's any future work that could improve or extend on the work you've done in this PR you can mention it so
this PR can be used as context for that.
-->
