### PR TITLE
Make `apply.sh` POSIX compatible

### DIFF
--- a/templates/distribution/scripts/apply.sh.tpl
+++ b/templates/distribution/scripts/apply.sh.tpl
@@ -48,8 +48,8 @@ additionalKappArgs=""
 
 {{- if eq .spec.distribution.modules.policy.type "gatekeeper" }}
     {{- if .spec.distribution.modules.policy.gatekeeper.installDefaultPolicies }}
-    # We need this to tell Kapp that the CRDs will be created later by Gatekeeper
-additionalKappArgs+="-f ../../vendor/modules/opa/katalog/tests/kapp/exists.yaml"
+# We need this to tell Kapp that the CRDs will be created later by Gatekeeper
+additionalKappArgs="-f ../../vendor/modules/opa/katalog/tests/kapp/exists.yaml"
     {{- end }}
 {{- end }}
 


### PR DESCRIPTION
### Summary 💡

This PR fixes an issue on some architectures, where the `sh` binary isn't symlinked and doesn't behave like `bash`.\

### Description 📝

This removes any non-POSIX syntax in the `apply.sh` file.

### Breaking Changes 💔
Nothing.

### Tests performed 🧪
- [x] Successfully install a cluster on affected machine.

### Future work 🔧
Make `bash` the default.
