### PR TITLE
fix(migrations/logging): to none without monitoring

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -18,10 +18,11 @@ The distribution is maintained with ❤️ by the team [SIGHUP by ReeVo](https:/
 
 ## Fixes 🐞
 - [[#387](https://github.com/sighupio/distribution/pull/387)]: This PR fixed an issue that prevented the control planes nodes array to be treated as immutable under the OnPremises provider. The number of control plane nodes was originally set as immutable in the 1.31.1 release cycle because there isn't any support to scale the etcd cluster with the number of control plane nodes in the SIGHUP Distribution yet. The issue allowed users to change the number of the control plane, even if it was explicitly marked as immutable.
-- [[#393](https://github.com/sighupio/distribution/pull/393)]: This PR fixes an issue present when users start the cluster with ingress type none, tls provider secret, and network policies disabled and try to enabled them afterwards.
+- [[#393](https://github.com/sighupio/distribution/pull/393)]: This PR fixes an issue present when users start the cluster with ingress type none, TLS provider secret, and network policies disabled and try to enable them afterwards.
+- [[#401](https://github.com/sighupio/distribution/pull/401)]: Fixed an error in uninstalling the logging module that prevented switching from any logging type to `none`.
 
 ### Security fixes
 
 ## Upgrade procedure
 
-Check the [upgrade docs](https://docs.kubernetesfury.com/docs/installation/upgrades) for the detailed procedure.
+Check the [upgrade docs](https://docs.sighup.io/docs/installation/upgrades/) for the detailed procedure.

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -19,7 +19,7 @@ The distribution is maintained with ❤️ by the team [SIGHUP by ReeVo](https:/
 ## Fixes 🐞
 - [[#387](https://github.com/sighupio/distribution/pull/387)]: This PR fixed an issue that prevented the control planes nodes array to be treated as immutable under the OnPremises provider. The number of control plane nodes was originally set as immutable in the 1.31.1 release cycle because there isn't any support to scale the etcd cluster with the number of control plane nodes in the SIGHUP Distribution yet. The issue allowed users to change the number of the control plane, even if it was explicitly marked as immutable.
 - [[#393](https://github.com/sighupio/distribution/pull/393)]: This PR fixes an issue present when users start the cluster with ingress type none, TLS provider secret, and network policies disabled and try to enable them afterwards.
-- [[#401](https://github.com/sighupio/distribution/pull/401)]: Fixed an error in uninstalling the logging module that prevented switching from any logging type to `none`.
+- [[#401](https://github.com/sighupio/distribution/pull/401)]: Fixed an error in uninstalling the logging module that prevented switching from any logging type to `none` when the monitoring module was not installed.
 
 ### Security fixes
 

--- a/templates/distribution/scripts/pre-apply.sh.tpl
+++ b/templates/distribution/scripts/pre-apply.sh.tpl
@@ -49,8 +49,8 @@ deleteOpensearch() {
 
 {{- if eq .spec.distribution.modules.monitoring.type "none" }}
   if ! $kubectlbin get apiservice v1.monitoring.coreos.com; then
-    cat delete-opensearch.yaml | $yqbin 'select(.apiVersion != "monitoring.coreos.com/v1")' > delete-opensearch-filtered.yaml
-    cp delete-opensearch-filtered.yaml delete-opensearch.yaml
+    $yqbin -i 'select(.apiVersion != "monitoring.coreos.com/v1")' delete-opensearch.yaml
+    $yqbin -i 'select(.apiVersion != "monitoring.coreos.com/v1")' delete-opensearch-dashboards.yaml
   fi
 {{- end }}
 
@@ -67,8 +67,7 @@ deleteLoki() {
 
 {{- if eq .spec.distribution.modules.monitoring.type "none" }}
   if ! $kubectlbin get apiservice v1.monitoring.coreos.com; then
-    cat delete-loki.yaml | $yqbin 'select(.apiVersion != "monitoring.coreos.com/v1")' > delete-loki-filtered.yaml
-    cp delete-loki-filtered.yaml delete-loki.yaml
+     $yqbin -i 'select(.apiVersion != "monitoring.coreos.com/v1")' delete-loki.yaml
   fi
 {{- end }}
 
@@ -80,11 +79,18 @@ deleteLoki() {
 
 deleteLoggingOperator() {
 
-  $kustomizebin build $vendorPath/modules/logging/katalog/logging-operated | $kubectlbin delete --ignore-not-found --wait --timeout=180s -f -
+  $kustomizebin build $vendorPath/modules/logging/katalog/logging-operated > delete-logging-operated.yaml
+  $kustomizebin build $vendorPath/modules/logging/katalog/logging-operator > delete-logging-operator.yaml
+{{- if eq .spec.distribution.modules.monitoring.type "none" }}
+  if ! $kubectlbin get apiservice v1.monitoring.coreos.com; then
+    $yqbin -i 'select(.apiVersion != "monitoring.coreos.com/v1")' delete-logging-operated.yaml
+    $yqbin -i 'select(.apiVersion != "monitoring.coreos.com/v1")' delete-logging-operator.yaml
+  fi
+{{- end }}
+
+  $kubectlbin delete --ignore-not-found --wait --timeout=180s -f delete-logging-operated.yaml
   $kustomizebin build $vendorPath/modules/logging/katalog/configs | $kubectlbin delete --ignore-not-found --wait --timeout=180s -f -
-
-  $kustomizebin build $vendorPath/modules/logging/katalog/logging-operator | $kubectlbin delete --ignore-not-found --wait --timeout=180s -f -
-
+  $kubectlbin delete --ignore-not-found --wait --timeout=180s -f delete-logging-operator.yaml
   echo "Logging Operator and NS deleted"
 }
 
@@ -94,8 +100,7 @@ $kustomizebin build $vendorPath/modules/logging/katalog/minio-ha > delete-loggin
 
 {{- if eq .spec.distribution.modules.monitoring.type "none" }}
   if ! $kubectlbin get apiservice v1.monitoring.coreos.com; then
-    cat delete-logging-minio-ha.yaml | $yqbin 'select(.apiVersion != "monitoring.coreos.com/v1")' > delete-logging-minio-ha-filtered.yaml
-    cp delete-logging-minio-ha-filtered.yaml delete-tracing-minio-ha.yaml
+    $yqbin -i 'select(.apiVersion != "monitoring.coreos.com/v1")' delete-logging-minio-ha.yaml
   fi
 {{- end }}
   $kubectlbin delete --ignore-not-found --wait --timeout=180s -f delete-logging-minio-ha.yaml


### PR DESCRIPTION
### Summary 💡

Fix migrations of logging from * to none when monitoring is disabled.

logging migrations to none (i.e. deleting logging resources) failed if _monitoring_ was none because we were trying to delete resources using the monitoring.coreos.com/v1 API that was not available. This fix filters out these type of resources from the deletion.

Closes: #400 

Relates: discovered while debugging #398 


### Description 📝

See summary

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested the change with KFD version v1.31.1 and verified that the migration finishes successfully and all resources are deleted.

### Future work 🔧

None