### PR TITLE
chore(schema): align Loki retentionPeriod with the naming convention

### DIFF
--- a/defaults/ekscluster-kfd-v1alpha2.yaml
+++ b/defaults/ekscluster-kfd-v1alpha2.yaml
@@ -113,8 +113,8 @@ data:
           secretAccessKey: example
           accessKeyId: example
           bucketName: lokibucket
-        # retentionPeriod can be set to 0s to disable retention
-        retentionPeriod: 720h # 30 days
+        # retentionTime can be set to 0s to disable retention
+        retentionTime: 720h # 30 days
       customOutputs: {}
     # monitoring module configuration
     monitoring:

--- a/defaults/kfddistribution-kfd-v1alpha2.yaml
+++ b/defaults/kfddistribution-kfd-v1alpha2.yaml
@@ -106,8 +106,8 @@ data:
           secretAccessKey: example
           accessKeyId: example
           bucketName: lokibucket
-        # retentionPeriod can be set to 0s to disable retention
-        retentionPeriod: 720h # 30 days
+        # retentionTime can be set to 0s to disable retention
+        retentionTime: 720h # 30 days
       customOutputs: {}
     # monitoring module configuration
     monitoring:

--- a/defaults/onpremises-kfd-v1alpha2.yaml
+++ b/defaults/onpremises-kfd-v1alpha2.yaml
@@ -106,8 +106,8 @@ data:
           secretAccessKey: example
           accessKeyId: example
           bucketName: lokibucket
-        # retentionPeriod can be set to 0s to disable retention
-        retentionPeriod: 720h # 30 days
+        # retentionTime can be set to 0s to disable retention
+        retentionTime: 720h # 30 days
       customOutputs: {}
     # monitoring module configuration
     monitoring:

--- a/docs/schemas/ekscluster-kfd-v1alpha2.md
+++ b/docs/schemas/ekscluster-kfd-v1alpha2.md
@@ -2496,7 +2496,7 @@ This value defines where the output from the `systemdEtcd` Flow will be sent. Th
 | [backend](#specdistributionmoduleslogginglokibackend)                   | `string` | Optional |
 | [externalEndpoint](#specdistributionmoduleslogginglokiexternalendpoint) | `object` | Optional |
 | [resources](#specdistributionmoduleslogginglokiresources)               | `object` | Optional |
-| [retentionPeriod](#specdistributionmoduleslogginglokiretentionperiod)   | `string` | Optional |
+| [retentionTime](#specdistributionmoduleslogginglokiretentiontime)       | `string` | Optional |
 | [tsdbStartDate](#specdistributionmoduleslogginglokitsdbstartdate)       | `string` | Required |
 
 ### Description
@@ -2615,7 +2615,7 @@ The CPU request for the Pod, in cores. Example: `500m`.
 
 The memory request for the Pod. Example: `500M`.
 
-## .spec.distribution.modules.logging.loki.retentionPeriod
+## .spec.distribution.modules.logging.loki.retentionTime
 
 ### Description
 

--- a/docs/schemas/kfddistribution-kfd-v1alpha2.md
+++ b/docs/schemas/kfddistribution-kfd-v1alpha2.md
@@ -1990,7 +1990,7 @@ This value defines where the output from the `systemdEtcd` Flow will be sent. Th
 | [backend](#specdistributionmoduleslogginglokibackend)                   | `string` | Optional |
 | [externalEndpoint](#specdistributionmoduleslogginglokiexternalendpoint) | `object` | Optional |
 | [resources](#specdistributionmoduleslogginglokiresources)               | `object` | Optional |
-| [retentionPeriod](#specdistributionmoduleslogginglokiretentionperiod)   | `string` | Optional |
+| [retentionTime](#specdistributionmoduleslogginglokiretentiontime)       | `string` | Optional |
 | [tsdbStartDate](#specdistributionmoduleslogginglokitsdbstartdate)       | `string` | Required |
 
 ### Description
@@ -2109,7 +2109,7 @@ The CPU request for the Pod, in cores. Example: `500m`.
 
 The memory request for the Pod. Example: `500M`.
 
-## .spec.distribution.modules.logging.loki.retentionPeriod
+## .spec.distribution.modules.logging.loki.retentionTime
 
 ### Description
 

--- a/docs/schemas/onpremises-kfd-v1alpha2.md
+++ b/docs/schemas/onpremises-kfd-v1alpha2.md
@@ -2267,7 +2267,7 @@ This value defines where the output from the `systemdEtcd` Flow will be sent. Th
 | [backend](#specdistributionmoduleslogginglokibackend)                   | `string` | Optional |
 | [externalEndpoint](#specdistributionmoduleslogginglokiexternalendpoint) | `object` | Optional |
 | [resources](#specdistributionmoduleslogginglokiresources)               | `object` | Optional |
-| [retentionPeriod](#specdistributionmoduleslogginglokiretentionperiod)   | `string` | Optional |
+| [retentionTime](#specdistributionmoduleslogginglokiretentiontime)       | `string` | Optional |
 | [tsdbStartDate](#specdistributionmoduleslogginglokitsdbstartdate)       | `string` | Required |
 
 ### Description
@@ -2386,7 +2386,7 @@ The CPU request for the Pod, in cores. Example: `500m`.
 
 The memory request for the Pod. Example: `500M`.
 
-## .spec.distribution.modules.logging.loki.retentionPeriod
+## .spec.distribution.modules.logging.loki.retentionTime
 
 ### Description
 

--- a/pkg/apis/ekscluster/v1alpha2/private/schema.go
+++ b/pkg/apis/ekscluster/v1alpha2/private/schema.go
@@ -1852,7 +1852,7 @@ type SpecDistributionModulesLoggingLoki struct {
 	// Optional retention period for logs stored in Loki (default `720h`, 30 days).
 	// Setting it to `0s` disables retention. Format must match:
 	// `[0-9]+(s|m|h|d|w|y)`.
-	RetentionPeriod *string `json:"retentionPeriod,omitempty" yaml:"retentionPeriod,omitempty" mapstructure:"retentionPeriod,omitempty"`
+	RetentionTime *string `json:"retentionTime,omitempty" yaml:"retentionTime,omitempty" mapstructure:"retentionTime,omitempty"`
 
 	// Starting from versions 1.28.4, 1.29.5 and 1.30.0 of SIGHUP Distribution, Loki
 	// changed the time series database from BoltDB to TSDB and the schema that it

--- a/pkg/apis/ekscluster/v1alpha2/public/schema.go
+++ b/pkg/apis/ekscluster/v1alpha2/public/schema.go
@@ -967,7 +967,7 @@ type SpecDistributionModulesLoggingLoki struct {
 	// Optional retention period for logs stored in Loki (default `720h`, 30 days).
 	// Setting it to `0s` disables retention. Format must match:
 	// `[0-9]+(s|m|h|d|w|y)`.
-	RetentionPeriod *string `json:"retentionPeriod,omitempty" yaml:"retentionPeriod,omitempty" mapstructure:"retentionPeriod,omitempty"`
+	RetentionTime *string `json:"retentionTime,omitempty" yaml:"retentionTime,omitempty" mapstructure:"retentionTime,omitempty"`
 
 	// Starting from versions 1.28.4, 1.29.5 and 1.30.0 of SIGHUP Distribution, Loki
 	// changed the time series database from BoltDB to TSDB and the schema that it

--- a/pkg/apis/kfddistribution/v1alpha2/public/schema.go
+++ b/pkg/apis/kfddistribution/v1alpha2/public/schema.go
@@ -910,7 +910,7 @@ type SpecDistributionModulesLoggingLoki struct {
 	// Optional retention period for logs stored in Loki (default `720h`, 30 days).
 	// Setting it to `0s` disables retention. Format must match:
 	// `[0-9]+(s|m|h|d|w|y)`.
-	RetentionPeriod *string `json:"retentionPeriod,omitempty" yaml:"retentionPeriod,omitempty" mapstructure:"retentionPeriod,omitempty"`
+	RetentionTime *string `json:"retentionTime,omitempty" yaml:"retentionTime,omitempty" mapstructure:"retentionTime,omitempty"`
 
 	// Starting from versions 1.28.4, 1.29.5 and 1.30.0 of SIGHUP Distribution, Loki
 	// changed the time series database from BoltDB to TSDB and the schema that it

--- a/pkg/apis/onpremises/v1alpha2/public/schema.go
+++ b/pkg/apis/onpremises/v1alpha2/public/schema.go
@@ -1061,7 +1061,7 @@ type SpecDistributionModulesLoggingLoki struct {
 	// Optional retention period for logs stored in Loki (default `720h`, 30 days).
 	// Setting it to `0s` disables retention. Format must match:
 	// `[0-9]+(s|m|h|d|w|y)`.
-	RetentionPeriod *string `json:"retentionPeriod,omitempty" yaml:"retentionPeriod,omitempty" mapstructure:"retentionPeriod,omitempty"`
+	RetentionTime *string `json:"retentionTime,omitempty" yaml:"retentionTime,omitempty" mapstructure:"retentionTime,omitempty"`
 
 	// Starting from versions 1.28.4, 1.29.5 and 1.30.0 of SIGHUP Distribution, Loki
 	// changed the time series database from BoltDB to TSDB and the schema that it

--- a/schemas/private/ekscluster-kfd-v1alpha2.json
+++ b/schemas/private/ekscluster-kfd-v1alpha2.json
@@ -1760,7 +1760,7 @@
           "format": "date",
           "description": "Starting from versions 1.28.4, 1.29.5 and 1.30.0 of SIGHUP Distribution, Loki changed the time series database from BoltDB to TSDB and the schema that it uses to store the logs from v11 to v13.\n\nThe value of this field will determine the date when Loki will start writing using the new TSDB and the schema v13, always at midnight UTC. The old BoltDB and schema will be kept until all the logs expire for reading purposes.\n\nFrom versions 1.29.7, 1.30.2 and 1.31.1 of the Distribution, this field will be immutable once set and its value should be a date before upgrading to one of these versions or creating the cluster, Loki does not support writing BoltDB and schema v11 anymore.\n\nValue must be a string in `ISO 8601` date format (`yyyy-mm-dd`). Example: `2024-11-18`."
         },
-        "retentionPeriod": {
+        "retentionTime": {
           "type": "string",
           "description": "Optional retention period for logs stored in Loki (default `720h`, 30 days). Setting it to `0s` disables retention. Format must match: `[0-9]+(s|m|h|d|w|y)`."
         },

--- a/schemas/public/ekscluster-kfd-v1alpha2.json
+++ b/schemas/public/ekscluster-kfd-v1alpha2.json
@@ -1747,7 +1747,7 @@
           "format": "date",
           "description": "Starting from versions 1.28.4, 1.29.5 and 1.30.0 of SIGHUP Distribution, Loki changed the time series database from BoltDB to TSDB and the schema that it uses to store the logs from v11 to v13.\n\nThe value of this field will determine the date when Loki will start writing using the new TSDB and the schema v13, always at midnight UTC. The old BoltDB and schema will be kept until all the logs expire for reading purposes.\n\nFrom versions 1.29.7, 1.30.2 and 1.31.1 of the Distribution, this field will be immutable once set and its value should be a date before upgrading to one of these versions or creating the cluster, Loki does not support writing BoltDB and schema v11 anymore.\n\nValue must be a string in `ISO 8601` date format (`yyyy-mm-dd`). Example: `2024-11-18`."
         },
-        "retentionPeriod": {
+        "retentionTime": {
           "type": "string",
           "description": "Optional retention period for logs stored in Loki (default `720h`, 30 days). Setting it to `0s` disables retention. Format must match: `[0-9]+(s|m|h|d|w|y)`."
         },

--- a/schemas/public/kfddistribution-kfd-v1alpha2.json
+++ b/schemas/public/kfddistribution-kfd-v1alpha2.json
@@ -637,7 +637,7 @@
           "format": "date",
           "description": "Starting from versions 1.28.4, 1.29.5 and 1.30.0 of SIGHUP Distribution, Loki changed the time series database from BoltDB to TSDB and the schema that it uses to store the logs from v11 to v13.\n\nThe value of this field will determine the date when Loki will start writing using the new TSDB and the schema v13, always at midnight UTC. The old BoltDB and schema will be kept until all the logs expire for reading purposes.\n\nFrom versions 1.29.7, 1.30.2 and 1.31.1 of the Distribution, this field will be immutable once set and its value should be a date before upgrading to one of these versions or creating the cluster, Loki does not support writing BoltDB and schema v11 anymore.\n\nValue must be a string in `ISO 8601` date format (`yyyy-mm-dd`). Example: `2024-11-18`."
         },
-        "retentionPeriod": {
+        "retentionTime": {
           "type": "string",
           "description": "Optional retention period for logs stored in Loki (default `720h`, 30 days). Setting it to `0s` disables retention. Format must match: `[0-9]+(s|m|h|d|w|y)`."
         },

--- a/schemas/public/onpremises-kfd-v1alpha2.json
+++ b/schemas/public/onpremises-kfd-v1alpha2.json
@@ -1282,7 +1282,7 @@
           "format": "date",
           "description": "Starting from versions 1.28.4, 1.29.5 and 1.30.0 of SIGHUP Distribution, Loki changed the time series database from BoltDB to TSDB and the schema that it uses to store the logs from v11 to v13.\n\nThe value of this field will determine the date when Loki will start writing using the new TSDB and the schema v13, always at midnight UTC. The old BoltDB and schema will be kept until all the logs expire for reading purposes.\n\nFrom versions 1.29.7, 1.30.2 and 1.31.1 of the Distribution, this field will be immutable once set and its value should be a date before upgrading to one of these versions or creating the cluster, Loki does not support writing BoltDB and schema v11 anymore.\n\nValue must be a string in `ISO 8601` date format (`yyyy-mm-dd`). Example: `2024-11-18`."
         },
-        "retentionPeriod": {
+        "retentionTime": {
           "type": "string",
           "description": "Optional retention period for logs stored in Loki (default `720h`, 30 days). Setting it to `0s` disables retention. Format must match: `[0-9]+(s|m|h|d|w|y)`."
         },

--- a/templates/distribution/manifests/logging/patches/loki-config.yaml.tpl
+++ b/templates/distribution/manifests/logging/patches/loki-config.yaml.tpl
@@ -71,7 +71,7 @@ limits_config:
   split_queries_by_interval: 15m
   volume_enabled: true
   max_label_names_per_series: 30
-  retention_period: {{ .spec.distribution.modules.logging.loki.retentionPeriod }}
+  retention_period: {{ .spec.distribution.modules.logging.loki.retentionTime }}
 memberlist:
   join_members:
   - loki-distributed-memberlist
@@ -135,7 +135,7 @@ storage_config:
       server_address: dns+loki-distributed-index-gateway-headless.logging.svc.cluster.local:9095
 compactor:
   working_directory: /var/loki/compactor
-  retention_enabled: {{ ne .spec.distribution.modules.logging.loki.retentionPeriod "0s" }}
+  retention_enabled: {{ ne .spec.distribution.modules.logging.loki.retentionTime "0s" }}
   retention_delete_delay: 2h
   retention_delete_worker_count: 150
   delete_request_store: s3


### PR DESCRIPTION
### Summary 💡

Renamed the `retentionPeriod` schema field since on all other fields for the same purpose we use `retentionTime`.

Relates: [sighupio/distribution/pull/396](https://github.com/sighupio/distribution/pull/396)

### Description 📝

See above.

### Breaking Changes 💔

None.

### Tests performed 🧪

Same tests describe [here](https://github.com/sighupio/distribution/pull/396)

### Future work 🔧

None.
