### PR TITLE
fix(templates): ingress cert-manager solvers

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -20,6 +20,7 @@ The distribution is maintained with ❤️ by the team [SIGHUP by ReeVo](https:/
 - [[#387](https://github.com/sighupio/distribution/pull/387)]: This PR fixed an issue that prevented the control planes nodes array to be treated as immutable under the OnPremises provider. The number of control plane nodes was originally set as immutable in the 1.31.1 release cycle because there isn't any support to scale the etcd cluster with the number of control plane nodes in the SIGHUP Distribution yet. The issue allowed users to change the number of the control plane, even if it was explicitly marked as immutable.
 - [[#393](https://github.com/sighupio/distribution/pull/393)]: This PR fixes an issue present when users start the cluster with ingress type none, TLS provider secret, and network policies disabled and try to enable them afterwards.
 - [[#401](https://github.com/sighupio/distribution/pull/401)]: Fixed an error in uninstalling the logging module that prevented switching from any logging type to `none` when the monitoring module was not installed.
+- [[#403](https://github.com/sighupio/distribution/pull/403)]: Fixed an error that prevented the generation of manifests when `ingress.nginx.type: none` and `ingress.certManager` configuration was not set.
 
 ### Security fixes
 

--- a/templates/distribution/manifests/ingress/kustomization.yaml.tpl
+++ b/templates/distribution/manifests/ingress/kustomization.yaml.tpl
@@ -54,9 +54,8 @@ patchesStrategicMerge:
 
   - patches/cert-manager-kapp-group.yml
 
-{{ if or (ne .spec.distribution.modules.ingress.nginx.tls.provider "none") (ne .spec.distribution.modules.ingress.nginx.type "none") }}
+  # cert-manager is always deployed, so we need to patch at least it to include the selectors
   - patches/infra-nodes.yml
-{{- end }}
 
 {{- end }}
 

--- a/templates/distribution/manifests/ingress/resources/cert-manager-clusterissuer.yml.tpl
+++ b/templates/distribution/manifests/ingress/resources/cert-manager-clusterissuer.yml.tpl
@@ -41,9 +41,9 @@ spec:
               tolerations:
                 {{ template "tolerations" ( merge (dict "indent" 16 "returnEmptyInsteadOfNull" true) $certManagerArgs ) }}
 {{- end -}}
-{{- else if .spec.distribution.modules.ingress.certManager.clusterIssuer.solvers }}
+{{- else if index .spec.distribution.modules.ingress.certManager.clusterIssuer "solvers" }}
     solvers:
-      {{ .spec.distribution.modules.ingress.certManager.clusterIssuer.solvers | toYaml | nindent 6 }}
+      {{- .spec.distribution.modules.ingress.certManager.clusterIssuer.solvers | toYaml | nindent 6 }}
 {{- end }}
 
 {{- end -}}


### PR DESCRIPTION
### Summary 💡

- Don't fail template rendering when cert-manager's solvers are not set.
- Always patch cert-manager's resources to use the nodeSelectors and Tolerations 

Fixes #211


### Description 📝

- Being that the default value for `ingress.tls.provider` is `certManager` without a `clusterIssuer.type` set, and there is not a default value for solvers, the template would fail trying to access the solvers key in the configuration. Changed to check if the key exists instead.

- When deploying the default configuration with `ingress.nginx.type: none` and `tls.provider` **not** set (so, cert-manager as per the defaults); the patch for adding `nodeSelectors` and `Tolerations` was not being applied. Now we apply always the patch, because cert-manager is always deployed.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested apply with `ingress.nginx.type: none` and no other fields specified -> template does not fail anymore and cert-manager gets deployed.
- [x] Tested apply with `ingress.nginx.type: none` and `tls.provider: none` ->  template does not fail anymore and cert-manager gets deployed.
- [x] Tested apply with `ingress.nginx.type: single` and `tls.provider: none` -> templates does not fail, both nginx and cert-manager get deployed.
- [x] Tested apply with `ingress.nginx.type: single` and `tls.provider: cert-manager` ->  templates does not fail, both nginx and cert-manager get deployed.
- [x] Tested apply with `ingress.nginx.type: single` and `tls.provider` not set ->  templates does not fail, both nginx and cert-manager get deployed.

### Future work 🔧

None