### PR TITLE
fix(templates/auth): show Gangplank in Forecastle

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -23,7 +23,7 @@ The distribution is maintained with ❤️ by the team [SIGHUP by ReeVo](https:/
 - [[#393](https://github.com/sighupio/distribution/pull/393)]: This PR fixes an issue present when users start the cluster with ingress type none, TLS provider secret, and network policies disabled and try to enable them afterwards.
 - [[#401](https://github.com/sighupio/distribution/pull/401)]: Fixed an error in uninstalling the logging module that prevented switching from any logging type to `none` when the monitoring module was not installed.
 - [[#403](https://github.com/sighupio/distribution/pull/403)]: Fixed an error that prevented the generation of manifests when `ingress.nginx.type: none` and `ingress.certManager` configuration was not set.
-- [[#406](https://github.com/sighupio/distribution/pull/406)]: Gangplank, the SD tool to generate kubeconfigs with SSO now shows up the Ingress directory (Forecastle).
+- [[#406](https://github.com/sighupio/distribution/pull/406)]: Gangplank, the SD tool to generate kubeconfigs with SSO, now shows up the Ingress directory (Forecastle).
 
 ### Security fixes
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -13,14 +13,17 @@ The distribution is maintained with ❤️ by the team [SIGHUP by ReeVo](https:/
 ## Breaking changes 💔
 
 ## New features 🌟
+
 - [[#396](https://github.com/sighupio/distribution/pull/396)]: This PR adds the retention configurations to Loki in logging module. This is an optional field to define retention period for logs stored in Loki. If not set, the default value is 30 days. Users can set it to `0s` to disable retention.
 - [[#391](https://github.com/sighupio/distribution/pull/391)]: With this PR users can enable the installation of network policies that will restrict the traffic across all the infrastructural namespaces of SD (SIGHUP Distribution) to just the access needed for its proper functioning and denying the rest of it. This experimental feature is now available also in the KFDDistribution provider.
 
 ## Fixes 🐞
+
 - [[#387](https://github.com/sighupio/distribution/pull/387)]: This PR fixed an issue that prevented the control planes nodes array to be treated as immutable under the OnPremises provider. The number of control plane nodes was originally set as immutable in the 1.31.1 release cycle because there isn't any support to scale the etcd cluster with the number of control plane nodes in the SIGHUP Distribution yet. The issue allowed users to change the number of the control plane, even if it was explicitly marked as immutable.
 - [[#393](https://github.com/sighupio/distribution/pull/393)]: This PR fixes an issue present when users start the cluster with ingress type none, TLS provider secret, and network policies disabled and try to enable them afterwards.
 - [[#401](https://github.com/sighupio/distribution/pull/401)]: Fixed an error in uninstalling the logging module that prevented switching from any logging type to `none` when the monitoring module was not installed.
 - [[#403](https://github.com/sighupio/distribution/pull/403)]: Fixed an error that prevented the generation of manifests when `ingress.nginx.type: none` and `ingress.certManager` configuration was not set.
+- [[#406](https://github.com/sighupio/distribution/pull/406)]: Gangplank, the SD tool to generate kubeconfigs with SSO now shows up the Ingress directory (Forecastle).
 
 ### Security fixes
 

--- a/templates/distribution/manifests/auth/resources/ingress-infra.yml.tpl
+++ b/templates/distribution/manifests/auth/resources/ingress-infra.yml.tpl
@@ -40,7 +40,7 @@ metadata:
     cluster.kfd.sighup.io/useful-link.url: https://{{ template "gangplankUrl" .spec }}
     cluster.kfd.sighup.io/useful-link.name: "Gangplank"
     forecastle.stakater.com/expose: "true"
-    forecastle.stakater.com/appName: "Gangkplank - SSO Kubeconfig"
+    forecastle.stakater.com/appName: "Gangplank - SSO Kubeconfig"
     forecastle.stakater.com/icon: "https://raw.githubusercontent.com/sighupio/distribution/refs/heads/main/docs/assets/black-logo.png"
   {{- if eq .spec.distribution.modules.ingress.nginx.tls.provider "certManager" }}
     {{ template "certManagerClusterIssuer" . }}

--- a/templates/distribution/manifests/auth/resources/ingress-infra.yml.tpl
+++ b/templates/distribution/manifests/auth/resources/ingress-infra.yml.tpl
@@ -38,7 +38,7 @@ metadata:
     cluster.kfd.sighup.io/useful-link.enable: "true"
   annotations:
     cluster.kfd.sighup.io/useful-link.url: https://{{ template "gangplankUrl" .spec }}
-    cluster.kfd.sighup.io/useful-link.name: "Gangplak"
+    cluster.kfd.sighup.io/useful-link.name: "Gangplank"
     forecastle.stakater.com/expose: "true"
     forecastle.stakater.com/appName: "Gankplank - SSO Kubeconfig"
     forecastle.stakater.com/icon: "https://raw.githubusercontent.com/sighupio/distribution/refs/heads/main/docs/assets/black-logo.png"

--- a/templates/distribution/manifests/auth/resources/ingress-infra.yml.tpl
+++ b/templates/distribution/manifests/auth/resources/ingress-infra.yml.tpl
@@ -40,7 +40,7 @@ metadata:
     cluster.kfd.sighup.io/useful-link.url: https://{{ template "gangplankUrl" .spec }}
     cluster.kfd.sighup.io/useful-link.name: "Gangplank"
     forecastle.stakater.com/expose: "true"
-    forecastle.stakater.com/appName: "Gankplank - SSO Kubeconfig"
+    forecastle.stakater.com/appName: "Gangkplank - SSO Kubeconfig"
     forecastle.stakater.com/icon: "https://raw.githubusercontent.com/sighupio/distribution/refs/heads/main/docs/assets/black-logo.png"
   {{- if eq .spec.distribution.modules.ingress.nginx.tls.provider "certManager" }}
     {{ template "certManagerClusterIssuer" . }}

--- a/templates/distribution/manifests/auth/resources/ingress-infra.yml.tpl
+++ b/templates/distribution/manifests/auth/resources/ingress-infra.yml.tpl
@@ -34,8 +34,15 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  {{- if eq .spec.distribution.modules.ingress.nginx.tls.provider "certManager" }}
+  labels:
+    cluster.kfd.sighup.io/useful-link.enable: "true"
   annotations:
+    cluster.kfd.sighup.io/useful-link.url: https://{{ template "gangplankUrl" .spec }}
+    cluster.kfd.sighup.io/useful-link.name: "Gangplak"
+    forecastle.stakater.com/expose: "true"
+    forecastle.stakater.com/appName: "Gankplank - SSO Kubeconfig"
+    forecastle.stakater.com/icon: "https://raw.githubusercontent.com/sighupio/distribution/refs/heads/main/docs/assets/black-logo.png"
+  {{- if eq .spec.distribution.modules.ingress.nginx.tls.provider "certManager" }}
     {{ template "certManagerClusterIssuer" . }}
   {{- end }}
   name: gangplank


### PR DESCRIPTION
### Summary 💡

Add labels and annotations to show an entry for Gangplank on Forecastle's Directory

### Description 📝

See summary

<img width="356" alt="image" src="https://github.com/user-attachments/assets/a8c11455-97d8-4adf-ad59-986e85ad7c02" />


### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested that the entry show properly with the right image and the link works.

### Future work 🔧

None