### PR TITLE
fix: tsdbStartDate immutability when migrating from logging.type: none to logging.type: loki

### DIFF
--- a/rules/ekscluster-kfd-v1alpha2.yaml
+++ b/rules/ekscluster-kfd-v1alpha2.yaml
@@ -11,13 +11,6 @@ distribution:
     description: "changes to the logging module type have been detected. This will cause the reconfiguration or deletion of the current logging stack."
     safe:
       - from: none
-    unsupported:
-      - to: opensearch
-        from: loki
-        reason: "currently, switching from opensearch to loki is not supported. You need to first remove the current stack with type: none."
-      - to: loki
-        from: opensearch
-        reason: "currently, switching from loki to opensearch is not supported. You need to first remove the current stack with type: none."
     reducers:
       - key: distributionModulesLoggingType
         lifecycle: pre-apply

--- a/rules/ekscluster-kfd-v1alpha2.yaml
+++ b/rules/ekscluster-kfd-v1alpha2.yaml
@@ -11,6 +11,13 @@ distribution:
     description: "changes to the logging module type have been detected. This will cause the reconfiguration or deletion of the current logging stack."
     safe:
       - from: none
+    unsupported:
+      - to: opensearch
+        from: loki
+        reason: "currently, switching from opensearch to loki is not supported. You need to first remove the current stack with type: none."
+      - to: loki
+        from: opensearch
+        reason: "currently, switching from loki to opensearch is not supported. You need to first remove the current stack with type: none."
     reducers:
       - key: distributionModulesLoggingType
         lifecycle: pre-apply
@@ -18,10 +25,15 @@ distribution:
     immutable: true
     description: "changes to Loki's TSDB start date have been detected. This parameter cannot be changed once set."
     safe:
-      - to: none
       - fromNodes:
         - path: ".spec.distribution.modules.logging.type"
-          value: none
+          from: "none"
+        - path: ".spec.distribution.modules.logging.type"
+          to: "none"
+        - path: ".spec.distribution.modules.logging.type"
+          from: "opensearch"
+        - path: ".spec.distribution.modules.logging.type"
+          to: "opensearch"
   - path: .spec.distribution.modules.monitoring.alertmanager.installDefaultRules
     immutable: false
     description: "changes to the monitoring alertmanager configs have been detected. This will cause the reconfiguration, creation or deletion of the default alertmanager configs."

--- a/rules/ekscluster-kfd-v1alpha2.yaml
+++ b/rules/ekscluster-kfd-v1alpha2.yaml
@@ -14,6 +14,14 @@ distribution:
     reducers:
       - key: distributionModulesLoggingType
         lifecycle: pre-apply
+  - path: .spec.distribution.modules.logging.loki.tsdbStartDate
+    immutable: true
+    description: "changes to Loki's TSDB start date have been detected. This parameter cannot be changed once set."
+    safe:
+      - to: none
+      - fromNodes:
+        - path: ".spec.distribution.modules.logging.type"
+          value: none
   - path: .spec.distribution.modules.monitoring.alertmanager.installDefaultRules
     immutable: false
     description: "changes to the monitoring alertmanager configs have been detected. This will cause the reconfiguration, creation or deletion of the default alertmanager configs."
@@ -78,7 +86,6 @@ distribution:
     reducers:
       - key: distributionModulesDRType
         lifecycle: pre-apply
-
   - path: .spec.distribution.modules.monitoring.type
     immutable: false
     description: "changes to the Monitoring module type have been detected. This will cause the reconfiguration or deletion of the current monitoring stack."

--- a/rules/kfddistribution-kfd-v1alpha2.yaml
+++ b/rules/kfddistribution-kfd-v1alpha2.yaml
@@ -14,6 +14,13 @@ distribution:
     reducers:
       - key: distributionModulesLoggingType
         lifecycle: pre-apply
+  - path: .spec.distribution.modules.logging.loki.tsdbStartDate
+    immutable: true
+    description: "changes to Loki's TSDB start date have been detected. This parameter cannot be changed once set."  
+    safe:
+      - fromNodes:
+        - path: ".spec.distribution.modules.logging.type"
+          from: none
   - path: .spec.distribution.modules.monitoring.alertmanager.installDefaultRules
     immutable: false
     description: "changes to the monitoring alertmanager configs have been detected. This will cause the reconfiguration, creation or deletion of the default alertmanager configs."

--- a/rules/kfddistribution-kfd-v1alpha2.yaml
+++ b/rules/kfddistribution-kfd-v1alpha2.yaml
@@ -11,13 +11,6 @@ distribution:
     description: "changes to the logging module type have been detected. This will cause the reconfiguration or deletion of the current logging stack."
     safe:
       - from: none
-    unsupported:
-      - to: opensearch
-        from: loki
-        reason: "currently, switching from opensearch to loki is not supported. You need to first remove the current stack with type: none."
-      - to: loki
-        from: opensearch
-        reason: "currently, switching from loki to opensearch is not supported. You need to first remove the current stack with type: none."
     reducers:
       - key: distributionModulesLoggingType
         lifecycle: pre-apply

--- a/rules/kfddistribution-kfd-v1alpha2.yaml
+++ b/rules/kfddistribution-kfd-v1alpha2.yaml
@@ -11,6 +11,13 @@ distribution:
     description: "changes to the logging module type have been detected. This will cause the reconfiguration or deletion of the current logging stack."
     safe:
       - from: none
+    unsupported:
+      - to: opensearch
+        from: loki
+        reason: "currently, switching from opensearch to loki is not supported. You need to first remove the current stack with type: none."
+      - to: loki
+        from: opensearch
+        reason: "currently, switching from loki to opensearch is not supported. You need to first remove the current stack with type: none."
     reducers:
       - key: distributionModulesLoggingType
         lifecycle: pre-apply
@@ -20,7 +27,13 @@ distribution:
     safe:
       - fromNodes:
         - path: ".spec.distribution.modules.logging.type"
-          from: none
+          from: "none"
+        - path: ".spec.distribution.modules.logging.type"
+          to: "none"
+        - path: ".spec.distribution.modules.logging.type"
+          from: "opensearch"
+        - path: ".spec.distribution.modules.logging.type"
+          to: "opensearch"
   - path: .spec.distribution.modules.monitoring.alertmanager.installDefaultRules
     immutable: false
     description: "changes to the monitoring alertmanager configs have been detected. This will cause the reconfiguration, creation or deletion of the default alertmanager configs."

--- a/rules/onpremises-kfd-v1alpha2.yaml
+++ b/rules/onpremises-kfd-v1alpha2.yaml
@@ -34,13 +34,6 @@ distribution:
     description: "changes to the logging module type have been detected. This will cause the reconfiguration or deletion of the current logging stack."
     safe:
       - from: none
-    unsupported:
-      - to: opensearch
-        from: loki
-        reason: "currently, switching from opensearch to loki is not supported. You need to first remove the current stack with type: none."
-      - to: loki
-        from: opensearch
-        reason: "currently, switching from loki to opensearch is not supported. You need to first remove the current stack with type: none."
     reducers:
       - key: distributionModulesLoggingType
         lifecycle: pre-apply

--- a/rules/onpremises-kfd-v1alpha2.yaml
+++ b/rules/onpremises-kfd-v1alpha2.yaml
@@ -34,6 +34,13 @@ distribution:
     description: "changes to the logging module type have been detected. This will cause the reconfiguration or deletion of the current logging stack."
     safe:
       - from: none
+    unsupported:
+      - to: opensearch
+        from: loki
+        reason: "currently, switching from opensearch to loki is not supported. You need to first remove the current stack with type: none."
+      - to: loki
+        from: opensearch
+        reason: "currently, switching from loki to opensearch is not supported. You need to first remove the current stack with type: none."
     reducers:
       - key: distributionModulesLoggingType
         lifecycle: pre-apply
@@ -43,7 +50,17 @@ distribution:
     safe:
       - fromNodes:
         - path: ".spec.distribution.modules.logging.type"
-          value: "none"
+          from: "none"
+        - path: ".spec.distribution.modules.logging.type"
+          to: "none"
+        - path: ".spec.distribution.modules.logging.type"
+          from: "opensearch"
+        - path: ".spec.distribution.modules.logging.type"
+          to: "opensearch"
+    unsupported:
+      - to: opensearch
+        from: loki
+        reason: "currently, switching Logging from loki to opensearch is not supported. You need to first remove the current stack with type: none."
   - path: .spec.distribution.modules.monitoring.alertmanager.installDefaultRules
     immutable: false
     description: "changes to the monitoring alertmanager configs have been detected. This will cause the reconfiguration, creation or deletion of the default alertmanager configs."

--- a/rules/onpremises-kfd-v1alpha2.yaml
+++ b/rules/onpremises-kfd-v1alpha2.yaml
@@ -40,6 +40,10 @@ distribution:
   - path: .spec.distribution.modules.logging.loki.tsdbStartDate
     immutable: true
     description: "changes to Loki's TSDB start date have been detected. This parameter cannot be changed once set."
+    safe:
+      - fromNodes:
+        - path: ".spec.distribution.modules.logging.type"
+          value: "none"
   - path: .spec.distribution.modules.monitoring.alertmanager.installDefaultRules
     immutable: false
     description: "changes to the monitoring alertmanager configs have been detected. This will cause the reconfiguration, creation or deletion of the default alertmanager configs."


### PR DESCRIPTION
### Summary 💡

fix immutability rules for `.spec.distribution.modules.logging.loki.tsdbStartDate`
it should be possible to migrate from `logging.type: none` to `logging.type: loki`

Closes: https://github.com/sighupio/distribution/issues/398

Relates:
- https://github.com/sighupio/furyctl/pull/610


### Description 📝

added new safe reducer to:
- `rules/ekscluster-kfd-v1alpha2.yaml`
- `rules/kfddistribution-kfd-v1alpha2.yaml`
- `rules/onpremises-kfd-v1alpha2.yaml`

### Breaking Changes 💔

none

### Tests performed 🧪

- [x] Tested with a kind cluster
  - migrating from logging.type: none to logging.type: loki -> does not get blocked
  - migrating from logging.type: loki to logging.type: opensearch -> does not get blocked
  - migrating from logging.type: loki to logging.type: none -> does not get blocked
  - migrating from logging.type: loki to logging.type: opensearch -> gets blocked, unsupported
  - regression test: migrating from ingress single to ingress dual -> still gets blocked

### Future work 🔧

none