### PR TITLE
Feat: add onpremises e2e upgrade tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -652,11 +652,11 @@ steps:
     - name: cache-upgrades
       path: /cache
 
-- name: install-cluster-with-furyctl-1.31.1
+- name: install-cluster-1.31.1-with-furyctl
   image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_1.9.0_4.33.3 # versions: awscli_bats_helm_kubectl_kustomize_tofu_yq
   environment:
     FURYCTL_VERSION: "v0.32.2"
-    DISTRIBUTION_VERSION: "v1.31.1"
+    DISTRIBUTION_VERSION: "v1.31.1" # distribution version is hardcoded in the tofu outputs
     DEBIAN_FRONTEND: noninteractive
     AWS_ACCESS_KEY_ID:
       from_secret: aws_access_key_id
@@ -684,11 +684,11 @@ steps:
     - name: cache-upgrades
       path: /cache
 
-- name: install-cluster-with-furyctl-1.31.1
+- name: upgrade-cluster-to-1.32.0-with-furyctl
   image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_1.9.0_4.33.3 # versions: awscli_bats_helm_kubectl_kustomize_tofu_yq
   environment:
     FURYCTL_VERSION: "v0.32.3-rc.0"
-    DISTRIBUTION_VERSION: "v1.32.0"
+    DISTRIBUTION_VERSION: "v1.32.0" # distribution version is hardcoded in the tofu outputs
     DEBIAN_FRONTEND: noninteractive
     AWS_ACCESS_KEY_ID:
       from_secret: aws_access_key_id

--- a/.drone.yml
+++ b/.drone.yml
@@ -643,7 +643,7 @@ steps:
     TF_VAR_hcloud_token:
       from_secret: hcloud_token
   commands:
-    - cd tests/e2e/onpremises/
+    - cd tests/e2e/onpremises-upgrades/
     - ssh-keygen -N '' -t rsa -b 4096 -C "sighup" -f /cache/ci-ssh-key
     - export TF_VAR_public_key=$(cat /cache/ci-ssh-key.pub)
     - export TF_VAR_private_key=$(cat /cache/ci-ssh-key)

--- a/.drone.yml
+++ b/.drone.yml
@@ -732,7 +732,7 @@ steps:
     TF_VAR_hcloud_token:
       from_secret: hcloud_token
   commands:
-    - cd tests/e2e/onpremises/
+    - cd tests/e2e/onpremises-upgrades/
     - export TF_VAR_public_key=$(cat /cache/ci-ssh-key.pub)
     - export TF_VAR_private_key=$(cat /cache/ci-ssh-key)
     - ansible-playbook 3.local-tofu-destroy.yaml

--- a/.drone.yml
+++ b/.drone.yml
@@ -607,6 +607,147 @@ volumes:
 - name: cache
   temp: {}
 ---
+name: e2e-onpremises-upgrades-1.31.1-1.32.0
+kind: pipeline
+type: docker
+
+node:
+   performance: low
+
+depends_on:
+  - qa
+
+clone:
+  depth: 1
+
+trigger:
+  ref:
+    - refs/tags/e2e-onpremises-**
+    - refs/tags/e2e-full-**
+    - refs/tags/v**
+
+steps:
+- name: create-hetzner-infrastructure
+  image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_1.9.0_4.33.3 # versions: awscli_bats_helm_kubectl_kustomize_tofu_yq
+  environment:
+    FURYCTL_VERSION: "v0.32.2"
+    DISTRIBUTION_VERSION: "v1.31.1"
+    DEBIAN_FRONTEND: noninteractive
+    AWS_ACCESS_KEY_ID:
+      from_secret: aws_access_key_id
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: aws_secret_access_key
+    AWS_REGION:
+      from_secret: aws_region
+    TF_VAR_ci_number: ${DRONE_BUILD_NUMBER}
+    TF_VAR_hcloud_token:
+      from_secret: hcloud_token
+  commands:
+    - cd tests/e2e/onpremises/
+    - ssh-keygen -N '' -t rsa -b 4096 -C "sighup" -f /cache/ci-ssh-key
+    - export TF_VAR_public_key=$(cat /cache/ci-ssh-key.pub)
+    - export TF_VAR_private_key=$(cat /cache/ci-ssh-key)
+    - ansible-playbook 0.local-tofu-run.yaml
+  volumes:
+    - name: cache-upgrades
+      path: /cache
+
+- name: install-cluster-with-furyctl-1.31.1
+  image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_1.9.0_4.33.3 # versions: awscli_bats_helm_kubectl_kustomize_tofu_yq
+  environment:
+    FURYCTL_VERSION: "v0.32.2"
+    DISTRIBUTION_VERSION: "v1.31.1"
+    DEBIAN_FRONTEND: noninteractive
+    AWS_ACCESS_KEY_ID:
+      from_secret: aws_access_key_id
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: aws_secret_access_key
+    AWS_REGION:
+      from_secret: aws_region
+    TF_VAR_ci_number: ${DRONE_BUILD_NUMBER}
+    TF_VAR_hcloud_token:
+      from_secret: hcloud_token
+  commands:
+    - cd tests/e2e/onpremises-upgrades/
+    - ansible-playbook 1.remote-furyctl-exec.yaml
+  volumes:
+    - name: cache-upgrades
+      path: /cache
+    
+- name: bats-tests
+  image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_1.9.0_4.33.3 # versions: awscli_bats_helm_kubectl_kustomize_tofu_yq
+  environment:
+    KUBECONFIG: /cache/kubeconfig
+  commands:
+    - ./tests/e2e/onpremises-upgrades/e2e-onpremises.sh
+  volumes:
+    - name: cache-upgrades
+      path: /cache
+
+- name: install-cluster-with-furyctl-1.31.1
+  image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_1.9.0_4.33.3 # versions: awscli_bats_helm_kubectl_kustomize_tofu_yq
+  environment:
+    FURYCTL_VERSION: "v0.32.3-rc.0"
+    DISTRIBUTION_VERSION: "v1.32.0"
+    DEBIAN_FRONTEND: noninteractive
+    AWS_ACCESS_KEY_ID:
+      from_secret: aws_access_key_id
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: aws_secret_access_key
+    AWS_REGION:
+      from_secret: aws_region
+    TF_VAR_ci_number: ${DRONE_BUILD_NUMBER}
+    TF_VAR_hcloud_token:
+      from_secret: hcloud_token
+  commands:
+    - cd tests/e2e/onpremises-upgrades/
+    - ansible-playbook 2.remote-furyctl-exec-upgrade.yaml
+  volumes:
+    - name: cache-upgrades
+      path: /cache
+    
+- name: bats-tests-upgrades
+  image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_1.9.0_4.33.3 # versions: awscli_bats_helm_kubectl_kustomize_tofu_yq
+  environment:
+    KUBECONFIG: /cache/kubeconfig
+  commands:
+    - ./tests/e2e/onpremises-upgrades/e2e-onpremises.sh
+  volumes:
+    - name: cache-upgrades
+      path: /cache
+
+- name: delete
+  image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_1.9.0_4.33.3 # versions: awscli_bats_helm_kubectl_kustomize_tofu_yq
+  environment:
+    FURYCTL_VERSION: "v0.32.3-rc.0"
+    DEBIAN_FRONTEND: noninteractive
+    DISTRIBUTION_VERSION: "v1.32.0"
+    AWS_ACCESS_KEY_ID:
+      from_secret: aws_access_key_id
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: aws_secret_access_key
+    AWS_REGION:
+      from_secret: aws_region
+    TF_VAR_ci_number: ${DRONE_BUILD_NUMBER}
+    TF_VAR_hcloud_token:
+      from_secret: hcloud_token
+  commands:
+    - cd tests/e2e/onpremises/
+    - export TF_VAR_public_key=$(cat /cache/ci-ssh-key.pub)
+    - export TF_VAR_private_key=$(cat /cache/ci-ssh-key)
+    - ansible-playbook 3.local-tofu-destroy.yaml
+  when:
+    status:
+    - success
+    - failure
+  volumes:
+    - name: cache-upgrades
+      path: /cache
+
+volumes:
+- name: cache-upgrades
+  temp: {}
+---
 kind: pipeline
 type: docker
 name: scheduled-aws-nuke

--- a/tests/e2e/onpremises-upgrades/0.local-tofu-run.yaml
+++ b/tests/e2e/onpremises-upgrades/0.local-tofu-run.yaml
@@ -1,0 +1,47 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+- name: Local Setup - Generate Terraform Files and furyctl Configuration
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  tasks:
+    - name: Run tofu init
+      ansible.builtin.command: tofu init
+
+    - name: Run tofu plan
+      ansible.builtin.command: tofu plan -out=terraform.plan
+
+    - name: Run tofu apply
+      ansible.builtin.command: tofu apply terraform.plan
+
+    - name: Extract furyctl_yaml output
+      ansible.builtin.shell: tofu output --raw furyctl_yaml > to_copy/furyctl.yaml
+
+    - name: Extract furyctl_upgrade_yaml output
+      ansible.builtin.shell: tofu output --raw furyctl_upgrade_yaml > to_copy/furyctl_upgrade.yaml
+
+    - name: Extract req_dns output
+      ansible.builtin.shell: tofu output --raw req_dns > to_copy/req-dns.cnf
+
+    - name: Get haproxy IP from Tofu Output
+      ansible.builtin.shell: tofu output -raw haproxy_ip
+      register: haproxy_ip_output
+
+    - name: Update hosts.yaml with haproxy IP
+      copy:
+        dest: "hosts.yaml"
+        content: |
+          all:
+            children:
+              haproxy:
+                hosts:
+                  haproxy:
+                    ansible_host: "{{ haproxy_ip_output.stdout }}"
+            vars:
+              ansible_python_interpreter: python3
+              ansible_ssh_private_key_file: "/cache/ci-ssh-key"
+              ansible_user: "root"

--- a/tests/e2e/onpremises-upgrades/1.remote-furyctl-exec.yaml
+++ b/tests/e2e/onpremises-upgrades/1.remote-furyctl-exec.yaml
@@ -1,0 +1,103 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+- name: Remote Setup - Configure and Deploy on Target Host
+  hosts: haproxy
+  gather_facts: false
+
+  tasks:
+    - name: Install required packages
+      apt:
+        name:
+          - ansible
+        state: present
+        update_cache: yes
+
+    - name: Copy files to remote host
+      ansible.builtin.copy:
+        src: "./to_copy/"
+        dest: "/root/"
+        owner: root
+        group: root
+        mode: 0755
+
+    - name: Install furyctl
+      ansible.builtin.shell: |
+        curl -L "https://github.com/sighupio/furyctl/releases/download/{{ furyctl_version }}/furyctl-$(uname -s)-amd64.tar.gz" | tar xz -C /usr/local/bin/
+      args:
+        creates: /usr/local/bin/furyctl
+      vars:
+        furyctl_version: "{{ lookup('env', 'FURYCTL_VERSION') | default('v0.32.1') }}"
+
+    - name: Create furyctl pki
+      ansible.builtin.shell: furyctl create pki -p ./pki
+      args:
+        chdir: /root
+      ignore_errors: yes
+      register: furyctl_pki
+
+    - name: Debug furyctl pki creation
+      debug:
+        msg: "{{ furyctl_pki.stdout }}"
+
+    - name: Run create_ingress_certs.sh
+      ansible.builtin.shell: ./create_ingress_certs.sh
+      args:
+        chdir: /root
+
+    - name: Create cluster with furyctl - Kubernetes phase
+      ansible.builtin.shell: furyctl apply cluster -o $PWD -D --phase kubernetes
+      args:
+        chdir: /root
+      register: furyctl_kubernetes
+
+    - name: Debug furyctl kubernetes phase
+      debug:
+        msg: "{{ furyctl_kubernetes.stdout }}"
+
+    - name: Copy prepare playbook on .furyctl ansible directory
+      ansible.builtin.shell: cp 00.prepare-hosts.yaml /root/.furyctl/reevo/kubernetes
+      args:
+        chdir: /root
+
+    - name: Run ansible prepare (prerequisites for storage)
+      ansible.builtin.shell: ansible-playbook 00.prepare-hosts.yaml
+      args:
+        chdir: /root/.furyctl/reevo/kubernetes
+
+    - name: Complete furyctl installation , all phases + post apply phase
+      ansible.builtin.shell: furyctl apply cluster -o $PWD -D --post-apply-phases distribution
+      args:
+        chdir: /root
+      register: furyctl_post_apply
+
+    - name: Debug furyctl with post apply phase
+      ansible.builtin.debug:
+        msg: "{{ furyctl_post_apply.stdout }}"
+
+    - name: Apply distribution again, in the case storage class is not yet available
+      ansible.builtin.shell: sleep 60 && furyctl apply cluster -o $PWD -D --phase distribution
+      args:
+        chdir: /root
+      register: furyctl_distribution
+
+    - name: Debug furyctl final apply
+      ansible.builtin.debug:
+        msg: "{{ furyctl_distribution.stdout }}"
+
+    - name: Slurp kubeconfig file
+      ansible.builtin.slurp:
+        src: "/root/kubeconfig"
+      register: kubeconfig_file
+
+    - name: Decode kubeconfig content
+      set_fact:
+        kubeconfig_decoded: "{{ kubeconfig_file.content | b64decode }}"
+
+    - name: Save kubeconfig to local machine
+      ansible.builtin.copy:
+        content: "{{ kubeconfig_decoded }}"
+        dest: "/cache/kubeconfig"
+      delegate_to: localhost

--- a/tests/e2e/onpremises-upgrades/2.remote-furyctl-exec-upgrade.yaml
+++ b/tests/e2e/onpremises-upgrades/2.remote-furyctl-exec-upgrade.yaml
@@ -1,0 +1,54 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+- name: Remote Setup - Configure and Deploy on Target Host
+  hosts: haproxy
+  gather_facts: false
+
+  tasks:
+    - name: Install furyctl
+      ansible.builtin.shell: |
+        curl -L "https://github.com/sighupio/furyctl/releases/download/{{ furyctl_version }}/furyctl-$(uname -s)-amd64.tar.gz" | tar xz -C /usr/local/bin/
+      args:
+        creates: /usr/local/bin/furyctl
+      vars:
+        furyctl_version: "{{ lookup('env', 'FURYCTL_VERSION') | default('v0.32.1') }}"
+
+    - name: Clone current commit distribution
+      ansible.builtin.shell: git clone https://github.com/sighupio/distribution.git /tmp/fury-distribution
+      args:
+        chdir: /root
+
+    - name: Clone current commit distribution
+      ansible.builtin.shell: git checkout {{ commit_sha }}
+      args:
+        chdir: /tmp/fury-distribution
+      vars:
+        commit_sha: "{{ lookup('env', 'DRONE_COMMIT_SHA') | default('main') }}"
+
+    - name: Upgrade cluster with furyctl
+      ansible.builtin.shell: furyctl apply cluster -o $PWD -D --distro-location /tmp/fury-distribution --force upgrades
+      args:
+        chdir: /root
+      register: furyctl_kubernetes
+
+    - name: Debug furyctl kubernetes phase
+      debug:
+        msg: "{{ furyctl_kubernetes.stdout }}"
+
+    - name: Slurp kubeconfig file
+      ansible.builtin.slurp:
+        src: "/root/kubeconfig"
+      register: kubeconfig_file
+
+    - name: Decode kubeconfig content
+      set_fact:
+        kubeconfig_decoded: "{{ kubeconfig_file.content | b64decode }}"
+
+    - name: Save kubeconfig to local machine
+      ansible.builtin.copy:
+        content: "{{ kubeconfig_decoded }}"
+        dest: "/cache/kubeconfig"
+      delegate_to: localhost

--- a/tests/e2e/onpremises-upgrades/3.local-tofu-destroy.yaml
+++ b/tests/e2e/onpremises-upgrades/3.local-tofu-destroy.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+- name: Local Setup - Destroy infrastructure
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  tasks:
+    - name: Run tofu destroy force
+      ansible.builtin.command: tofu apply -destroy -auto-approve
+

--- a/tests/e2e/onpremises-upgrades/access.tf
+++ b/tests/e2e/onpremises-upgrades/access.tf
@@ -1,0 +1,8 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+resource "hcloud_ssh_key" "ssh_key" {
+  name       = "E2E SSH Key upgrades ${var.ci_number}"
+  public_key = var.public_key
+}

--- a/tests/e2e/onpremises-upgrades/ansible.cfg
+++ b/tests/e2e/onpremises-upgrades/ansible.cfg
@@ -1,0 +1,12 @@
+# Copyright (c) 2022 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+[defaults]
+inventory = hosts.yaml
+host_key_checking = False
+roles_path = ./roles
+timeout = 90
+stdout_callback = yaml
+bin_ansible_callbacks = True
+

--- a/tests/e2e/onpremises-upgrades/e2e-onpremises.sh
+++ b/tests/e2e/onpremises-upgrades/e2e-onpremises.sh
@@ -139,14 +139,3 @@ load ./helper
     status=${loop_it_result}
     [[ "$status" -eq 0 ]]
 }
-
-@test "Kyverno Admission controller is Running" {
-    info
-    test(){
-        readyReplicas=$(kubectl get deploy kyverno-admission-controller -n kyverno -o jsonpath="{.status.readyReplicas}")
-        if [ "${readyReplicas}" != "3" ]; then return 1; fi
-    }
-    loop_it test 60 10
-    status=${loop_it_result}
-    [[ "$status" -eq 0 ]]
-}

--- a/tests/e2e/onpremises-upgrades/e2e-onpremises.sh
+++ b/tests/e2e/onpremises-upgrades/e2e-onpremises.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bats
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# shellcheck disable=SC2154
+
+load ./helper
+
+@test "Velero is Running" {
+    info
+    test() {
+        kubectl get pods -l k8s-app=velero -o json -n kube-system |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "Velero Node Agent is Running" {
+    info
+    test() {
+        kubectl get pods -l k8s-app=velero-node-agent -o json -n kube-system |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "Cert-manager Controller is Running" {
+    info
+    test() {
+        kubectl get pods -l app=cert-manager -o json -n cert-manager |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "Nginx Ingress Controller is Running" {
+    info
+    test() {
+        kubectl get pods -l app=ingress-nginx -o json -n ingress-nginx |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "Forecastle is Running" {
+    info
+    test() {
+        kubectl get pods -l app=forecastle -o json -n ingress-nginx |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "Fluentd is Running" {
+    info
+    test() {
+        kubectl get pods -l app.kubernetes.io/name=fluentd -o json -n logging |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+
+@test "Grafana is Running" {
+    info
+    test() {
+        kubectl get pods -l app.kubernetes.io/name=grafana -o json -n monitoring |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "Prometheus Operator is Running" {
+    info
+    test() {
+        kubectl get pods -l app.kubernetes.io/name=prometheus-operator -o json -n monitoring |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "Kube State Metrics is Running" {
+    info
+    test() {
+        kubectl get pods -l app.kubernetes.io/name=kube-state-metrics -o json -n monitoring |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "Node Exporter is Running" {
+    info
+    test() {
+        kubectl get pods -l app.kubernetes.io/name=node-exporter -o json -n monitoring |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "Prometheus is Running" {
+    info
+    test() {
+        kubectl get pods -l app.kubernetes.io/name=prometheus -o json -n monitoring | jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
+
+    }
+    loop_it test 160 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "kube-proxy-metrics is Running" {
+    info
+    test() {
+        kubectl get pods -l k8s-app=kube-proxy-metrics -o json -n monitoring | jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "tempo is Running" {
+    info
+    test(){
+        data=$(kubectl get sts -n tracing -l app.kubernetes.io/component=ingester -o json | jq '.items[] | select(.metadata.name == "tempo-distributed-ingester" and .status.replicas == .status.readyReplicas)')
+        if [ "${data}" == "" ]; then return 1; fi
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [[ "$status" -eq 0 ]]
+}
+
+@test "Kyverno Admission controller is Running" {
+    info
+    test(){
+        readyReplicas=$(kubectl get deploy kyverno-admission-controller -n kyverno -o jsonpath="{.status.readyReplicas}")
+        if [ "${readyReplicas}" != "3" ]; then return 1; fi
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [[ "$status" -eq 0 ]]
+}

--- a/tests/e2e/onpremises-upgrades/firewall.tf
+++ b/tests/e2e/onpremises-upgrades/firewall.tf
@@ -1,0 +1,26 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+resource "hcloud_firewall" "haproxy" {
+  name = "e2e-firewall-upgrades-${var.ci_number}"
+
+  rule {
+    direction = "in"
+    protocol  = "icmp"
+    source_ips = [
+      "0.0.0.0/0",
+      "::/0"
+    ]
+  }
+
+  rule {
+    direction = "in"
+    protocol  = "tcp"
+    port      = "1-65535"
+    source_ips = [
+      "0.0.0.0/0",
+      "::/0"
+    ]
+  }
+}

--- a/tests/e2e/onpremises-upgrades/helper.bash
+++ b/tests/e2e/onpremises-upgrades/helper.bash
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC2154,SC2034,SC2086
+
+apply (){
+  kustomize build $1 >&2
+  kustomize build $1 | kubectl apply -f - --server-side 2>&3
+}
+
+delete (){
+  kustomize build $1 >&2
+  kustomize build $1 | kubectl delete -f - 2>&3
+}
+
+info(){
+  echo -e "${BATS_TEST_NUMBER}: ${BATS_TEST_DESCRIPTION}" >&3
+}
+
+loop_it(){
+  retry_counter=0
+  max_retry=${2:-100}
+  wait_time=${3:-2}
+  run ${1}
+  ko=${status}
+  loop_it_result=${ko}
+  while [[ ko -ne 0 ]]
+  do
+    if [ $retry_counter -ge $max_retry ]; then
+      echo "Timeout waiting for the command to success."
+      echo "Last command output was:"
+      echo "${output}"
+      return 1
+    fi
+    sleep ${wait_time} && echo "# waiting..." $retry_counter >&3
+    run ${1}
+    ko=${status}
+    loop_it_result=${ko}
+    retry_counter=$((retry_counter + 1))
+  done
+  return 0
+}

--- a/tests/e2e/onpremises-upgrades/hosts.yaml
+++ b/tests/e2e/onpremises-upgrades/hosts.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+all:
+  children:
+    haproxy:
+      hosts:
+        haproxy:
+          ansible_host: "1.2.3.4"
+  vars:
+    ansible_python_interpreter: python3
+    ansible_ssh_private_key_file: "/cache/ci-ssh-key"
+    ansible_user: "root"

--- a/tests/e2e/onpremises-upgrades/main.tf
+++ b/tests/e2e/onpremises-upgrades/main.tf
@@ -1,0 +1,21 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+terraform {
+  required_providers {
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = "~> 1.45"
+    }
+  }
+  backend "s3" {
+    bucket = "tf-state-e2e-fury-ci"
+    key    = "hetzner/e2e-upgrades-${var.ci_number}"
+    region = "eu-west-1"
+  }
+}
+
+provider "hcloud" {
+  token = var.hcloud_token
+}

--- a/tests/e2e/onpremises-upgrades/network.tf
+++ b/tests/e2e/onpremises-upgrades/network.tf
@@ -1,0 +1,14 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+resource "hcloud_network" "network" {
+  name     = "e2e-upgrades-${var.ci_number}"
+  ip_range = "10.10.0.0/16"
+}
+
+resource "hcloud_network_subnet" "network_subnet" {
+  type         = "cloud"
+  network_id   = hcloud_network.network.id
+  network_zone = "eu-central"
+  ip_range     = "10.10.1.0/24"
+}

--- a/tests/e2e/onpremises-upgrades/nodes.tf
+++ b/tests/e2e/onpremises-upgrades/nodes.tf
@@ -1,0 +1,90 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+resource "hcloud_server" "haproxy" {
+  name        = "haproxy-0-upgrades-${var.ci_number}"
+  image       = "ubuntu-24.04"
+  server_type = "cpx31"
+  location    = "nbg1"
+
+  ssh_keys = [hcloud_ssh_key.ssh_key.id]
+  network {
+    network_id = hcloud_network.network.id
+    ip         = "10.10.1.2"
+  }
+  firewall_ids = [hcloud_firewall.haproxy.id]
+}
+
+resource "null_resource" "init_haproxy" {
+  triggers = {
+    instance_id   = hcloud_server.haproxy.id
+    private_key   = var.private_key
+  }
+
+  connection {
+    type        = "ssh"
+    host        = hcloud_server.haproxy.ipv4_address
+    user        = "root"
+    private_key = var.private_key
+  }
+
+  provisioner "remote-exec" {
+    inline = [ 
+      "echo \"IdentityFile ~/.ssh/id_ed25519\" > /root/.ssh/config ",
+      "echo \"${var.private_key}\" > /root/.ssh/id_ed25519",
+      "chmod 600 /root/.ssh/id_ed25519"
+     ]
+  }
+
+}
+
+resource "hcloud_server" "controlplane" {
+  count       = 3
+  name        = "controlplane-upgrades-${count.index}-${var.ci_number}"
+  image       = "ubuntu-24.04"
+  server_type = "cpx31"
+  location    = "nbg1"
+  ssh_keys    = [hcloud_ssh_key.ssh_key.id]
+  network {
+    network_id = hcloud_network.network.id
+    ip         = "10.10.1.${count.index + 3}"
+  }
+  public_net {
+    ipv4_enabled = true
+    ipv6_enabled = false
+  }
+}
+
+resource "hcloud_server" "infra" {
+  count       = 3
+  name        = "infra-upgrades-${count.index}-${var.ci_number}"
+  image       = "ubuntu-24.04"
+  server_type = "cpx41"
+  location    = "nbg1"
+  ssh_keys    = [hcloud_ssh_key.ssh_key.id]
+  network {
+    network_id = hcloud_network.network.id
+    ip         = "10.10.1.${count.index + 6}"
+  }
+    public_net {
+    ipv4_enabled = true
+    ipv6_enabled = false
+  }
+}
+
+resource "hcloud_server" "worker" {
+  count       = 2
+  name        = "worker-upgrades-${count.index}-${var.ci_number}"
+  image       = "ubuntu-24.04"
+  server_type = "cpx41"
+  location    = "nbg1"
+  ssh_keys    = [hcloud_ssh_key.ssh_key.id]
+  network {
+    network_id = hcloud_network.network.id
+    ip         = "10.10.1.${count.index + 9}"
+  }
+  public_net {
+    ipv4_enabled = true
+    ipv6_enabled = false
+  }
+}

--- a/tests/e2e/onpremises-upgrades/output.tf
+++ b/tests/e2e/onpremises-upgrades/output.tf
@@ -1,0 +1,327 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+output "haproxy_ip" {
+  value = hcloud_server.haproxy.ipv4_address
+}
+
+output "ingress_domain" {
+  value = "ingress.${replace(hcloud_server.haproxy.ipv4_address, ".", "-")}.nip.io"
+}
+
+output "furyctl_yaml" {
+  value = <<EOF
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: OnPremises
+metadata:
+  name: reevo
+spec:
+  distributionVersion: v1.31.1
+  kubernetes:
+    pkiFolder: ./pki
+    ssh:
+      username: root
+      keyPath: /cache/ci-ssh-key
+    dnsZone: nip.io
+    controlPlaneAddress: ${replace(hcloud_server.haproxy.ipv4_address, ".", "-")}.nip.io:6443
+    podCidr: 10.128.0.0/14
+    svcCidr: 172.30.0.0/16
+    loadBalancers:
+      enabled: true
+      hosts:
+        - name: haproxy-10-10-1-2
+          ip: 10.10.1.2
+      keepalived:
+        enabled: false
+        interface: enp0s6
+        ip: 10.250.250.179/32
+        virtualRouterId: "201"
+        passphrase: "b16cf069"
+      stats:
+        username: admin
+        password: "password"
+      additionalConfig: "{file://./haproxy-additional.cfg}"
+    masters:
+      hosts:
+        - name: controlplane0-10-10-1-3
+          ip: 10.10.1.3
+        - name: controlplane1-10-10-1-4
+          ip: 10.10.1.4
+        - name: controlplane2-10-10-1-5
+          ip: 10.10.1.5
+    nodes:
+      - name: infra
+        hosts:
+          - name: infra0-10-10-1-6
+            ip: 10.10.1.6
+          - name: infra1-10-10-1-7
+            ip: 10.10.1.7
+          - name: infra2-10-10-1-8
+            ip: 10.10.1.8
+        taints: []
+      - name: worker
+        hosts:
+          - name: worker0-10-10-1-9
+            ip: 10.10.1.9
+          - name: worker1-10-10-1-10
+            ip: 10.10.1.10
+        taints: []
+    #advancedAnsible:
+      #config: |
+      #  ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p -q root@${hcloud_server.haproxy.ipv4_address}"'
+    advanced: 
+      encryption:
+        configuration: "{file://./encrypted-secret-config.yaml}"
+  distribution:
+    common:
+      nodeSelector:
+         node.kubernetes.io/role: infra
+      #tolerations:
+      #  - effect: NoSchedule
+      #    key: node.kubernetes.io/role
+      #    value: infra
+      networkPoliciesEnabled: true
+    modules:
+      networking:
+        type: calico
+      ingress:
+        baseDomain: ingress.${replace(hcloud_server.haproxy.ipv4_address, ".", "-")}.nip.io
+        nginx:
+          type: single
+          tls:
+            provider: secret
+            secret:
+              cert: "{file://tls.crt}"
+              key: "{file://tls.key}"
+              ca: "{file://ca.crt}"
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: samuele.chiocca@reevo.it
+            type: http01
+      logging: 
+        type: loki
+        opensearch:
+          type: triple
+        loki: 
+          backend: minio
+          tsdbStartDate: "2024-11-18"
+      monitoring:
+        type: mimir
+        mimir: 
+          retentionTime: 3d
+          backend: minio
+        prometheus:
+          retentionTime: 1d
+          retentionSize: 5GiB
+          storageSize: 20Gi
+        alertmanager:
+          installDefaultRules: false
+      policy: 
+        type: gatekeeper
+        gatekeeper:
+          enforcementAction: warn
+          installDefaultPolicies: true 
+      dr:
+        type: on-premises
+        velero: 
+          backend: minio
+          schedules:
+            install: true
+            definitions:
+              full:
+                snapshotMoveData: true
+          snapshotController:
+            install: true
+      tracing: 
+        type: tempo
+        tempo: 
+          backend: minio
+      auth:
+        provider:
+          type: none
+
+
+  plugins:
+    helm:
+      repositories:
+        - name: longhorn
+          url: https://charts.longhorn.io
+      releases:
+        - name: longhorn
+          namespace: longhorn-system
+          chart: longhorn/longhorn
+          version: '1.8.1'
+          set:
+            - name: persistence.defaultClassReplicaCount
+              value: "2"
+EOF
+}
+
+output "furyctl_upgrade_yaml" {
+  value = <<EOF
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: OnPremises
+metadata:
+  name: reevo
+spec:
+  distributionVersion: v1.32.0
+  kubernetes:
+    pkiFolder: ./pki
+    ssh:
+      username: root
+      keyPath: /cache/ci-ssh-key
+    dnsZone: nip.io
+    controlPlaneAddress: ${replace(hcloud_server.haproxy.ipv4_address, ".", "-")}.nip.io:6443
+    podCidr: 10.128.0.0/14
+    svcCidr: 172.30.0.0/16
+    loadBalancers:
+      enabled: true
+      hosts:
+        - name: haproxy-10-10-1-2
+          ip: 10.10.1.2
+      keepalived:
+        enabled: false
+        interface: enp0s6
+        ip: 10.250.250.179/32
+        virtualRouterId: "201"
+        passphrase: "b16cf069"
+      stats:
+        username: admin
+        password: "password"
+      additionalConfig: "{file://./haproxy-additional.cfg}"
+    masters:
+      hosts:
+        - name: controlplane0-10-10-1-3
+          ip: 10.10.1.3
+        - name: controlplane1-10-10-1-4
+          ip: 10.10.1.4
+        - name: controlplane2-10-10-1-5
+          ip: 10.10.1.5
+    nodes:
+      - name: infra
+        hosts:
+          - name: infra0-10-10-1-6
+            ip: 10.10.1.6
+          - name: infra1-10-10-1-7
+            ip: 10.10.1.7
+          - name: infra2-10-10-1-8
+            ip: 10.10.1.8
+        taints: []
+      - name: worker
+        hosts:
+          - name: worker0-10-10-1-9
+            ip: 10.10.1.9
+          - name: worker1-10-10-1-10
+            ip: 10.10.1.10
+        taints: []
+    #advancedAnsible:
+      #config: |
+      #  ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p -q root@${hcloud_server.haproxy.ipv4_address}"'
+    advanced: 
+      encryption:
+        configuration: "{file://./encrypted-secret-config.yaml}"
+  distribution:
+    common:
+      nodeSelector:
+         node.kubernetes.io/role: infra
+      #tolerations:
+      #  - effect: NoSchedule
+      #    key: node.kubernetes.io/role
+      #    value: infra
+      networkPoliciesEnabled: true
+    modules:
+      networking:
+        type: calico
+      ingress:
+        baseDomain: ingress.${replace(hcloud_server.haproxy.ipv4_address, ".", "-")}.nip.io
+        nginx:
+          type: single
+          tls:
+            provider: secret
+            secret:
+              cert: "{file://tls.crt}"
+              key: "{file://tls.key}"
+              ca: "{file://ca.crt}"
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: samuele.chiocca@reevo.it
+            type: http01
+      logging: 
+        type: loki
+        opensearch:
+          type: triple
+        loki: 
+          backend: minio
+          tsdbStartDate: "2024-11-18"
+      monitoring:
+        type: mimir
+        mimir: 
+          retentionTime: 3d
+          backend: minio
+        prometheus:
+          retentionTime: 1d
+          retentionSize: 5GiB
+          storageSize: 20Gi
+        alertmanager:
+          installDefaultRules: false
+      policy: 
+        type: gatekeeper
+        gatekeeper:
+          enforcementAction: warn
+          installDefaultPolicies: true 
+      dr:
+        type: on-premises
+        velero: 
+          backend: minio
+          schedules:
+            install: true
+            definitions:
+              full:
+                snapshotMoveData: true
+          snapshotController:
+            install: true
+      tracing: 
+        type: tempo
+        tempo: 
+          backend: minio
+      auth:
+        provider:
+          type: none
+
+
+  plugins:
+    helm:
+      repositories:
+        - name: longhorn
+          url: https://charts.longhorn.io
+      releases:
+        - name: longhorn
+          namespace: longhorn-system
+          chart: longhorn/longhorn
+          version: '1.8.1'
+          set:
+            - name: persistence.defaultClassReplicaCount
+              value: "2"
+EOF
+}
+
+output "req_dns" {
+  value = <<EOF
+[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = ingress.${replace(hcloud_server.haproxy.ipv4_address, ".", "-")}.nip.io
+DNS.2 = *.ingress.${replace(hcloud_server.haproxy.ipv4_address, ".", "-")}.nip.io
+EOF
+}

--- a/tests/e2e/onpremises-upgrades/to_copy/00.prepare-hosts.yaml
+++ b/tests/e2e/onpremises-upgrades/to_copy/00.prepare-hosts.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Install required packages using package module
+      apt:
+        name:
+          - net-tools
+          - open-iscsi
+          - cryptsetup
+        state: present
+        update_cache: yes #
+
+    - name: Load dm_crypt module
+      command: modprobe dm_crypt

--- a/tests/e2e/onpremises-upgrades/to_copy/create_ingress_certs.sh
+++ b/tests/e2e/onpremises-upgrades/to_copy/create_ingress_certs.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+openssl genrsa -out ca-key.pem 2048
+openssl req -x509 -new -days 365 -nodes -key ca-key.pem -out ca.crt -subj "/CN=ingress-ca"
+openssl genrsa -out tls.key 2048
+openssl req -new -key tls.key -out csr.pem -subj "/CN=ingress-ca" -config req-dns.cnf
+openssl x509 -req -in csr.pem -CA ca.crt -CAkey ca-key.pem -CAcreateserial -out tls.crt -days 365 -extensions v3_req -extfile req-dns.cnf

--- a/tests/e2e/onpremises-upgrades/to_copy/encrypted-secret-config.yaml
+++ b/tests/e2e/onpremises-upgrades/to_copy/encrypted-secret-config.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+apiVersion: apiserver.config.k8s.io/v1
+kind: EncryptionConfiguration
+resources:
+  - resources:
+    - secrets
+    providers:
+    - aescbc:
+        keys:
+        - name: key1
+          # base64 encoding of "passwordonatipo" (without quotes)
+          secret: cGFzc3dvcmRvbmF0aXBvCg== 
+    # as a fallback to read non encrypted secrets
+    - identity: {}

--- a/tests/e2e/onpremises-upgrades/to_copy/haproxy-additional.cfg
+++ b/tests/e2e/onpremises-upgrades/to_copy/haproxy-additional.cfg
@@ -1,0 +1,20 @@
+frontend ingress-http
+    mode tcp
+    bind *:80
+    default_backend ingress-http
+
+backend ingress-http
+    server infra1 10.10.1.6:31080 maxconn 256 check # send-proxy
+    server infra2 10.10.1.7:31080 maxconn 256 check # send-proxy
+    server infra3 10.10.1.8:31080 maxconn 256 check # send-proxy
+
+frontend ingress-https
+    mode tcp
+    bind *:443
+    default_backend ingress-https
+
+backend ingress-https
+    server infra1 10.10.1.6:31443 maxconn 256 check # send-proxy
+    server infra2 10.10.1.7:31443 maxconn 256 check # send-proxy
+    server infra3 10.10.1.8:31443 maxconn 256 check # send-proxy
+

--- a/tests/e2e/onpremises-upgrades/variables.tf
+++ b/tests/e2e/onpremises-upgrades/variables.tf
@@ -1,0 +1,22 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+variable "hcloud_token" {
+  type = string
+  sensitive = true
+}
+
+variable "public_key" {
+  type = string
+  sensitive = true
+}
+
+variable "private_key"{
+  type = string
+  sensitive = true
+}
+
+variable "ci_number" {
+  type = string
+}

--- a/tests/e2e/onpremises/1.remote-furyctl-exec.yaml
+++ b/tests/e2e/onpremises/1.remote-furyctl-exec.yaml
@@ -47,8 +47,20 @@
       args:
         chdir: /root
 
+    - name: Clone current commit distribution
+      ansible.builtin.shell: git clone https://github.com/sighupio/distribution.git /tmp/fury-distribution
+      args:
+        chdir: /root
+
+    - name: Clone current commit distribution
+      ansible.builtin.shell: git checkout {{ commit_sha }}
+      args:
+        chdir: /tmp/fury-distribution
+      vars:
+        commit_sha: "{{ lookup('env', 'DRONE_COMMIT_SHA') | default('main') }}"
+
     - name: Create cluster with furyctl - Kubernetes phase
-      ansible.builtin.shell: furyctl apply cluster -o $PWD -D --phase kubernetes
+      ansible.builtin.shell: furyctl apply cluster -o $PWD -D --phase kubernetes --distro-location /tmp/fury-distribution
       args:
         chdir: /root
       register: furyctl_kubernetes
@@ -68,7 +80,7 @@
         chdir: /root/.furyctl/reevo/kubernetes
 
     - name: Complete furyctl installation , all phases + post apply phase
-      ansible.builtin.shell: furyctl apply cluster -o $PWD -D --post-apply-phases distribution
+      ansible.builtin.shell: furyctl apply cluster -o $PWD -D --post-apply-phases distribution --distro-location /tmp/fury-distribution
       args:
         chdir: /root
       register: furyctl_post_apply
@@ -78,7 +90,7 @@
         msg: "{{ furyctl_post_apply.stdout }}"
 
     - name: Apply distribution again, in the case storage class is not yet available
-      ansible.builtin.shell: sleep 60 && furyctl apply cluster -o $PWD -D --phase distribution
+      ansible.builtin.shell: sleep 60 && furyctl apply cluster -o $PWD -D --phase distribution --distro-location /tmp/fury-distribution
       args:
         chdir: /root
       register: furyctl_distribution

--- a/tests/e2e/onpremises/output.tf
+++ b/tests/e2e/onpremises/output.tf
@@ -18,7 +18,7 @@ kind: OnPremises
 metadata:
   name: reevo
 spec:
-  distributionVersion: v1.32.0-rc.3
+  distributionVersion: v1.32.0
   kubernetes:
     pkiFolder: ./pki
     ssh:


### PR DESCRIPTION
### Summary 💡

This PR adds e2e tests to test onpremises cluster upgrades.

### Description 📝

The overall goal of this PR is to have a baseline testing on the OnPremises provider, that was tested manually on each release.

**I also changed the behaviour of the standard onpremises e2e test, using the current distribution commit folder to create the cluster instead of an RC tag.**

### Breaking Changes 💔

- None

### Passing e2e tests

- https://ci.sighup.io/sighupio/distribution/3252/1/5
