### PR TITLE
Feat/update installer eks for alinux2023 compatibility

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -332,6 +332,7 @@ clone:
 trigger:
   ref:
     - refs/tags/e2e-eks-**
+    - refs/tags/e2e-full-eks-**
     - refs/tags/e2e-full-**
     - refs/tags/v**
 
@@ -357,6 +358,95 @@ steps:
     - mv furyctl /usr/local/bin
     - chmod +x /usr/local/bin/furyctl
     - ./tests/e2e/ekscluster/e2e-ekscluster.sh
+
+- name: furyctl-delete
+  image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_1.9.0_4.33.3 # versions: awscli_bats_helm_kubectl_kustomize_yq
+  environment:
+    FURYCTL_VERSION: "v0.32.3-rc.2"
+    CLUSTER_NAME: e2e-eks-${DRONE_BUILD_NUMBER}
+    DEBIAN_FRONTEND: noninteractive
+    DISTRIBUTION_VERSION: "v1.32.0"
+    AWS_ACCESS_KEY_ID:
+      from_secret: aws_access_key_id
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: aws_secret_access_key
+    AWS_REGION:
+      from_secret: aws_region
+  commands:
+    - apt update
+    - apt-get install -y expect
+    - echo "Installing the correct furyctl version..."
+    - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-linux-amd64.tar.gz" | tar -xz
+    - mv furyctl /usr/local/bin
+    - chmod +x /usr/local/bin/furyctl
+    - tests/e2e/ekscluster/furyctl_delete.expect $(cat ./last_furyctl_yaml.txt)
+    - aws s3 rm s3://e2e-drone-eks/$CLUSTER_NAME --recursive
+
+- name: furyctl-delete-force
+  image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_1.9.0_4.33.3 # versions: awscli_bats_helm_kubectl_kustomize_yq
+  environment:
+    FURYCTL_VERSION: "v0.32.3-rc.2"
+    CLUSTER_NAME: e2e-eks-${DRONE_BUILD_NUMBER}-upgrades
+    DEBIAN_FRONTEND: noninteractive
+    DISTRIBUTION_VERSION: "v1.32.0"
+    AWS_ACCESS_KEY_ID:
+      from_secret: aws_access_key_id
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: aws_secret_access_key
+    AWS_REGION:
+      from_secret: aws_region
+  commands:
+    - apt update
+    - apt-get install -y expect
+    - echo "Installing the correct furyctl version..."
+    - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-linux-amd64.tar.gz" | tar -xz
+    - mv furyctl /usr/local/bin
+    - chmod +x /usr/local/bin/furyctl
+    - tests/e2e/ekscluster/furyctl_delete_force.expect tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.31.1.yaml
+    - aws s3 rm s3://e2e-drone-eks/$CLUSTER_NAME --recursive
+  when:
+    status:
+    - failure
+---
+name: e2e-ekscluster-selfmanaged-nodes-1.32.0
+kind: pipeline
+type: docker
+
+node:
+   performance: low
+
+depends_on:
+  - qa
+
+clone:
+  depth: 1
+
+trigger:
+  ref:
+    - refs/tags/e2e-full-eks-**
+
+steps:
+- name: run-tests
+  image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_1.9.0_4.33.3 # versions: awscli_bats_helm_kubectl_kustomize_yq
+  environment:
+    FURYCTL_VERSION: "v0.32.3-rc.2"
+    DISTRIBUTION_VERSION: "v1.32.0"
+    DEBIAN_FRONTEND: noninteractive
+    CLUSTER_NAME: e2e-eks-${DRONE_BUILD_NUMBER}
+    AWS_ACCESS_KEY_ID:
+      from_secret: aws_access_key_id
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: aws_secret_access_key
+    AWS_REGION:
+      from_secret: aws_region
+  commands:
+    - apt update
+    - apt-get install -y expect
+    - echo "Installing the correct furyctl version..."
+    - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-linux-amd64.tar.gz" | tar -xz
+    - mv furyctl /usr/local/bin
+    - chmod +x /usr/local/bin/furyctl
+    - ./tests/e2e/ekscluster/e2e-ekscluster-selfmanaged.sh
 
 - name: furyctl-delete
   image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_1.9.0_4.33.3 # versions: awscli_bats_helm_kubectl_kustomize_yq

--- a/kfd.yaml
+++ b/kfd.yaml
@@ -16,7 +16,7 @@ modules:
 kubernetes:
   eks:
     version: 1.32
-    installer: v3.2.0
+    installer: v3.2.1-rc0
   onpremises:
     version: 1.32.4
     installer: v1.32.4

--- a/tests/e2e/ekscluster/e2e-ekscluster-selfmanaged.sh
+++ b/tests/e2e/ekscluster/e2e-ekscluster-selfmanaged.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+set -e
+
+LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-selfmanaged-alinux2-init-cluster.yaml
+tests/e2e/ekscluster/replace_variables.sh --distribution-version "$DISTRIBUTION_VERSION" --cluster-name "$CLUSTER_NAME" --furyctl-yaml "$LAST_FURYCTL_YAML"
+echo "----------------------------------------------------------------------------"
+echo "Executing furyctl with self-managed nodes with alinux2"
+tests/e2e/ekscluster/furyctl_apply.expect "$LAST_FURYCTL_YAML" /tmp ./
+echo "$LAST_FURYCTL_YAML" > last_furyctl_yaml.txt
+echo "Testing that the components are running"
+bats -t tests/e2e/ekscluster/e2e-ekscluster-init-cluster.sh
+
+
+LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-selfmanaged-alinux2-init-cluster.yaml
+tests/e2e/ekscluster/replace_variables.sh --distribution-version "$DISTRIBUTION_VERSION" --cluster-name "$CLUSTER_NAME" --furyctl-yaml "$LAST_FURYCTL_YAML"
+echo "----------------------------------------------------------------------------"
+echo "Executing furyctl with self-managed nodes with alinux2023"
+tests/e2e/ekscluster/furyctl_apply.expect "$LAST_FURYCTL_YAML" /tmp ./
+echo "$LAST_FURYCTL_YAML" > last_furyctl_yaml.txt
+echo "Testing that the components are running"
+bats -t tests/e2e/ekscluster/e2e-ekscluster-init-cluster.sh

--- a/tests/e2e/ekscluster/manifests/furyctl-cleanup-all.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-cleanup-all.yaml
@@ -75,8 +75,10 @@ spec:
           volumeSize: 50
           volumeType: gp2
         labels:
-          nodepool: infra
-          node.kubernetes.io/role: infra
+          nodepool: "infra"
+          node.kubernetes.io/role: "infra"
+        taints:
+          - node.kubernetes.io/role=infra:NoSchedule
         tags:
           k8s.io/cluster-autoscaler/node-template/label/nodepool: worker
           k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: worker
@@ -85,6 +87,13 @@ spec:
       users: []
       roles: []
   distribution:
+    common:
+      nodeSelector:
+        node.kubernetes.io/role: infra
+      tolerations:
+        - effect: NoSchedule
+          key: node.kubernetes.io/role
+          value: infra
     modules:
       ingress:
         baseDomain: internal.e2e.ci.sighup.cc

--- a/tests/e2e/ekscluster/manifests/furyctl-init-cluster.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-init-cluster.yaml
@@ -75,8 +75,10 @@ spec:
           volumeSize: 50
           volumeType: gp2
         labels:
-          nodepool: infra
-          node.kubernetes.io/role: infra
+          nodepool: "infra"
+          node.kubernetes.io/role: "infra"
+        taints:
+          - node.kubernetes.io/role=infra:NoSchedule
         tags:
           k8s.io/cluster-autoscaler/node-template/label/nodepool: worker
           k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: worker
@@ -85,6 +87,13 @@ spec:
       users: []
       roles: []
   distribution:
+    common:
+      nodeSelector:
+        node.kubernetes.io/role: infra
+      tolerations:
+        - effect: NoSchedule
+          key: node.kubernetes.io/role
+          value: infra
     modules:
       ingress:
         baseDomain: internal.e2e.ci.sighup.cc

--- a/tests/e2e/ekscluster/manifests/furyctl-selfmanaged-alinux2-init-cluster.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-selfmanaged-alinux2-init-cluster.yaml
@@ -1,0 +1,165 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/sighupio/fury-distribution/v1.32.0/schemas/public/ekscluster-kfd-v1alpha2.json
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+
+# This is a sample configuration file to be used as a starting point. For the
+# complete reference of the configuration file schema, please refer to the
+# official documentation:
+# https://docs.kubernetesfury.com/docs/furyctl/providers/ekscluster
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: EKSCluster
+metadata:
+  name: e2e-test-eks
+spec:
+  distributionVersion: v1.32.0
+  toolsConfiguration:
+    terraform:
+      state:
+        s3:
+          bucketName: e2e-drone-eks
+          keyPrefix: e2e-test-eks
+          region: eu-west-1
+  region: eu-west-1
+  tags:
+    env: e2e-test-eks
+  infrastructure:
+    vpc:
+      network:
+        cidr: 10.1.0.0/16
+        subnetsCidrs:
+          private:
+            - 10.1.0.0/20
+            - 10.1.16.0/20
+            - 10.1.32.0/20
+          public:
+            - 10.1.48.0/24
+            - 10.1.49.0/24
+            - 10.1.50.0/24
+    vpn:
+      instances: 0
+      port: 1194
+      instanceType: t3.micro
+      diskSize: 50
+      operatorName: sighup
+      dhParamsBits: 2048
+      vpnClientsSubnetCidr: 172.16.0.0/16
+      ssh:
+        githubUsersName:
+          - Filo01
+        allowedFromCidrs:
+          - 0.0.0.0/0
+  kubernetes:
+    nodeAllowedSshPublicKey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA1xMG9TEH97YhkmoehlMaAMwqi9NOIx2ItXKNv2KVnI
+    nodePoolGlobalAmiType: alinux2
+    nodePoolsLaunchKind: launch_templates
+    apiServer:
+      privateAccess: true
+      publicAccess: true
+      privateAccessCidrs:
+        - 0.0.0.0/0
+      publicAccessCidrs:
+        - 0.0.0.0/0
+    nodePools:
+      - name: infra
+        type: self-managed
+        size:
+          min: 6
+          max: 9
+        instance:
+          type: t3.xlarge
+          spot: false
+          volumeSize: 50
+          volumeType: gp2
+        labels:
+          nodepool: "infra"
+          node.kubernetes.io/role: "infra"
+        taints:
+          - node.kubernetes.io/role=infra:NoSchedule
+        tags:
+          k8s.io/cluster-autoscaler/node-template/label/nodepool: worker
+          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: worker
+    awsAuth:
+      additionalAccounts: []
+      users: []
+      roles: []
+  distribution:
+    common:
+      nodeSelector:
+        node.kubernetes.io/role: infra
+      tolerations:
+        - effect: NoSchedule
+          key: node.kubernetes.io/role
+          value: infra
+    modules:
+      ingress:
+        baseDomain: internal.e2e.ci.sighup.cc
+        nginx:
+          type: dual
+          tls:
+            provider: certManager
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: test@sighup.io
+            type: http01
+        dns:
+          public:
+            name: e2e.ci.sighup.cc
+            create: true
+          private:
+            name: internal.e2e.ci.sighup.cc
+            create: true
+      logging:
+        type: loki
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword1
+        loki:
+          backend: minio
+          tsdbStartDate: '2024-11-21'
+      monitoring:
+        type: mimir
+        prometheus:
+          resources:
+            requests:
+              cpu: 10m
+            limits:
+              cpu: 2000m
+              memory: 6Gi
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword2
+      tracing:
+        type: tempo
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword3
+      policy:
+        type: kyverno
+        kyverno:
+          additionalExcludedNamespaces:
+            - local-path-storage
+          validationFailureAction: Enforce
+          installDefaultPolicies: true
+      dr:
+        type: eks
+        velero:
+          eks:
+            bucketName: e2e-test-eks
+            region: eu-west-1
+      auth:
+        provider:
+          type: basicAuth
+          basicAuth:
+            username: test
+            password: testpassword

--- a/tests/e2e/ekscluster/manifests/furyctl-selfmanaged-alinux2023-init-cluster.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-selfmanaged-alinux2023-init-cluster.yaml
@@ -1,0 +1,165 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/sighupio/fury-distribution/v1.32.0/schemas/public/ekscluster-kfd-v1alpha2.json
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+
+# This is a sample configuration file to be used as a starting point. For the
+# complete reference of the configuration file schema, please refer to the
+# official documentation:
+# https://docs.kubernetesfury.com/docs/furyctl/providers/ekscluster
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: EKSCluster
+metadata:
+  name: e2e-test-eks
+spec:
+  distributionVersion: v1.32.0
+  toolsConfiguration:
+    terraform:
+      state:
+        s3:
+          bucketName: e2e-drone-eks
+          keyPrefix: e2e-test-eks
+          region: eu-west-1
+  region: eu-west-1
+  tags:
+    env: e2e-test-eks
+  infrastructure:
+    vpc:
+      network:
+        cidr: 10.1.0.0/16
+        subnetsCidrs:
+          private:
+            - 10.1.0.0/20
+            - 10.1.16.0/20
+            - 10.1.32.0/20
+          public:
+            - 10.1.48.0/24
+            - 10.1.49.0/24
+            - 10.1.50.0/24
+    vpn:
+      instances: 0
+      port: 1194
+      instanceType: t3.micro
+      diskSize: 50
+      operatorName: sighup
+      dhParamsBits: 2048
+      vpnClientsSubnetCidr: 172.16.0.0/16
+      ssh:
+        githubUsersName:
+          - Filo01
+        allowedFromCidrs:
+          - 0.0.0.0/0
+  kubernetes:
+    nodeAllowedSshPublicKey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA1xMG9TEH97YhkmoehlMaAMwqi9NOIx2ItXKNv2KVnI
+    nodePoolGlobalAmiType: alinux2023
+    nodePoolsLaunchKind: launch_templates
+    apiServer:
+      privateAccess: true
+      publicAccess: true
+      privateAccessCidrs:
+        - 0.0.0.0/0
+      publicAccessCidrs:
+        - 0.0.0.0/0
+    nodePools:
+      - name: infra
+        type: self-managed
+        size:
+          min: 6
+          max: 9
+        instance:
+          type: t3.xlarge
+          spot: false
+          volumeSize: 50
+          volumeType: gp2
+        labels:
+          nodepool: "infra"
+          node.kubernetes.io/role: "infra"
+        taints:
+          - node.kubernetes.io/role=infra:NoSchedule
+        tags:
+          k8s.io/cluster-autoscaler/node-template/label/nodepool: worker
+          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: worker
+    awsAuth:
+      additionalAccounts: []
+      users: []
+      roles: []
+  distribution:
+    common:
+      nodeSelector:
+        node.kubernetes.io/role: infra
+      tolerations:
+        - effect: NoSchedule
+          key: node.kubernetes.io/role
+          value: infra
+    modules:
+      ingress:
+        baseDomain: internal.e2e.ci.sighup.cc
+        nginx:
+          type: dual
+          tls:
+            provider: certManager
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: test@sighup.io
+            type: http01
+        dns:
+          public:
+            name: e2e.ci.sighup.cc
+            create: true
+          private:
+            name: internal.e2e.ci.sighup.cc
+            create: true
+      logging:
+        type: loki
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword1
+        loki:
+          backend: minio
+          tsdbStartDate: '2024-11-21'
+      monitoring:
+        type: mimir
+        prometheus:
+          resources:
+            requests:
+              cpu: 10m
+            limits:
+              cpu: 2000m
+              memory: 6Gi
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword2
+      tracing:
+        type: tempo
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword3
+      policy:
+        type: kyverno
+        kyverno:
+          additionalExcludedNamespaces:
+            - local-path-storage
+          validationFailureAction: Enforce
+          installDefaultPolicies: true
+      dr:
+        type: eks
+        velero:
+          eks:
+            bucketName: e2e-test-eks
+            region: eu-west-1
+      auth:
+        provider:
+          type: basicAuth
+          basicAuth:
+            username: test
+            password: testpassword


### PR DESCRIPTION
### Summary 💡

- Updated `installer-eks` module to `v3.2.1-rc0`
- Updated e2e eks tests

Relates:
[amiType alinux2023 not working anymore due to deprecated bootstrap.sh](https://github.com/sighupio/installer-eks/issues/88)

### Description 📝

AMI type for `alinux2023` is broken on the old version of the `installer-eks` as [described here]https://github.com/sighupio/installer-eks/issues/88)
- Updated `kfd.yaml` to use `v3.2.1-rc0`
- Updated e2e eks tests to use taints and tolerations
- Created new e2e eks tests that use `self-managed` nodes with both `alinux2023` and `alinux2`
- Created a new trigger to run those tests via `refs/tags/e2e-full-eks-**`

### Breaking Changes 💔

None

### Tests performed 🧪

- Tested with distro versions `v1.30.2` `v1.31.1` `v1.32.0`
- Tested upgrades from `v1.30.2` to `v1.31.1` to `v1.32.0`

