### PR TITLE
Add warning in release note for v1.32.0

### DIFF
--- a/docs/releases/v1.30.2.md
+++ b/docs/releases/v1.30.2.md
@@ -1,13 +1,11 @@
 # SIGHUP Distribution Release v1.29.7
 
 > [!CAUTION]
-> **Use furyctl >= 0.32.4 to upgrade to this version.**
+> **Use furyctl >= 0.32.5 to upgrade to this version.**
 > This EKSCluster version used the version `v3.2.0` of the installer-eks that had an issue with `selfmanaged` nodes using `alinux2023`.
 > This issue was patched in `v3.2.1` of the installer and is automatically used when using `furyctl >= 0.32.4`.
-
-> [!CAUTION]
-> There is an issue that was fixed in furyctl version `0.32.5`, which failed the cluster upgrade when `gatekeeper` was enabled. Only the OnPremises provider is impacted.
-> Impacted upgrade paths are: 
+> **Additional Issue:** There is an issue that was fixed in furyctl version `0.32.5`, which failed the cluster upgrade when `gatekeeper` was enabled. Only the OnPremises provider is impacted.
+> Impacted upgrade paths are:
 > - 1.29.7-1.30.2
 > - 1.30.2-1.31.1
 > - 1.31.1-1.32.0

--- a/docs/releases/v1.30.2.md
+++ b/docs/releases/v1.30.2.md
@@ -5,6 +5,13 @@
 > This EKSCluster version used the version `v3.2.0` of the installer-eks that had an issue with `selfmanaged` nodes using `alinux2023`.
 > This issue was patched in `v3.2.1` of the installer and is automatically used when using `furyctl >= 0.32.4`.
 
+> [!CAUTION]
+> There is an issue that was fixed in furyctl version `0.32.5`, which failed the cluster upgrade when `gatekeeper` was enabled. Only the OnPremises provider is impacted.
+> Impacted upgrade paths are: 
+> - 1.29.7-1.30.2
+> - 1.30.2-1.31.1
+> - 1.31.1-1.32.0
+
 Welcome to SD release `v1.29.7`.
 
 The distribution is maintained with ❤️ by the team [SIGHUP by ReeVo](https://sighup.io/).

--- a/docs/releases/v1.31.1.md
+++ b/docs/releases/v1.31.1.md
@@ -5,6 +5,13 @@
 > This EKSCluster version used the version `v3.2.0` of the installer-eks that had an issue with `selfmanaged` nodes using `alinux2023`.
 > This issue was patched in `v3.2.1` of the installer and is automatically used when using `furyctl >= 0.32.4`.
 
+> [!CAUTION]
+> There is an issue that was fixed in furyctl version `0.32.5`, which failed the cluster upgrade when `gatekeeper` was enabled. Only the OnPremises provider is impacted.
+> Impacted upgrade paths are: 
+> - 1.29.7-1.30.2
+> - 1.30.2-1.31.1
+> - 1.31.1-1.32.0
+
 Welcome to SD release `v1.31.1`.
 
 The distribution is maintained with ❤️ by the team [SIGHUP by ReeVo](https://sighup.io/).

--- a/docs/releases/v1.31.1.md
+++ b/docs/releases/v1.31.1.md
@@ -1,13 +1,11 @@
 # SIGHUP Distribution Release v1.31.1
 
 > [!CAUTION]
-> **Use furyctl >= 0.32.4 to upgrade to this version.**
+> **Use furyctl >= 0.32.5 to upgrade to this version.**
 > This EKSCluster version used the version `v3.2.0` of the installer-eks that had an issue with `selfmanaged` nodes using `alinux2023`.
 > This issue was patched in `v3.2.1` of the installer and is automatically used when using `furyctl >= 0.32.4`.
-
-> [!CAUTION]
-> There is an issue that was fixed in furyctl version `0.32.5`, which failed the cluster upgrade when `gatekeeper` was enabled. Only the OnPremises provider is impacted.
-> Impacted upgrade paths are: 
+> **Additional Issue:** There is an issue that was fixed in furyctl version `0.32.5`, which failed the cluster upgrade when `gatekeeper` was enabled. Only the OnPremises provider is impacted.
+> Impacted upgrade paths are:
 > - 1.29.7-1.30.2
 > - 1.30.2-1.31.1
 > - 1.31.1-1.32.0

--- a/docs/releases/v1.32.0.md
+++ b/docs/releases/v1.32.0.md
@@ -4,7 +4,13 @@
 > **Use furyctl >= 0.32.5 to upgrade to this version.**
 > This EKSCluster version used the version `v3.2.0` of the installer-eks that had an issue with `selfmanaged` nodes using `alinux2023`.
 > This issue was patched in `v3.2.1` of the installer and is automatically used when using `furyctl >= 0.32.4`.
-> There is also another issue that was fixed in furyctl version `0.32.5`, which presented when upgrading an OnPremises cluster with `gatekeeper` enabled. Other providers were not impacted.
+
+> [!CAUTION]
+> There is an issue that was fixed in furyctl version `0.32.5`, which failed the cluster upgrade when `gatekeeper` was enabled. Only the OnPremises provider is impacted.
+> Impacted upgrade paths are: 
+> - 1.29.7-1.30.2
+> - 1.30.2-1.31.1
+> - 1.31.1-1.32.0
 
 Welcome to SD release `v1.32.0`.
 

--- a/docs/releases/v1.32.0.md
+++ b/docs/releases/v1.32.0.md
@@ -4,10 +4,8 @@
 > **Use furyctl >= 0.32.5 to upgrade to this version.**
 > This EKSCluster version used the version `v3.2.0` of the installer-eks that had an issue with `selfmanaged` nodes using `alinux2023`.
 > This issue was patched in `v3.2.1` of the installer and is automatically used when using `furyctl >= 0.32.4`.
-
-> [!CAUTION]
-> There is an issue that was fixed in furyctl version `0.32.5`, which failed the cluster upgrade when `gatekeeper` was enabled. Only the OnPremises provider is impacted.
-> Impacted upgrade paths are: 
+> **Additional Issue:** There is an issue that was fixed in furyctl version `0.32.5`, which failed the cluster upgrade when `gatekeeper` was enabled. Only the OnPremises provider is impacted.
+> Impacted upgrade paths are:
 > - 1.29.7-1.30.2
 > - 1.30.2-1.31.1
 > - 1.31.1-1.32.0

--- a/docs/releases/v1.32.0.md
+++ b/docs/releases/v1.32.0.md
@@ -1,9 +1,10 @@
 # SIGHUP Distribution Release v1.32.0
 
 > [!CAUTION]
-> **Use furyctl >= 0.32.4 to upgrade to this version.**
+> **Use furyctl >= 0.32.5 to upgrade to this version.**
 > This EKSCluster version used the version `v3.2.0` of the installer-eks that had an issue with `selfmanaged` nodes using `alinux2023`.
 > This issue was patched in `v3.2.1` of the installer and is automatically used when using `furyctl >= 0.32.4`.
+> There is also another issue that was fixed in furyctl version `0.32.5`, which presented when upgrading an OnPremises cluster with `gatekeeper` enabled. Other providers were not impacted.
 
 Welcome to SD release `v1.32.0`.
 


### PR DESCRIPTION
### Summary 💡

Add warning to use latest furyctl version when upgrading to version v1.32.0 of the distribution.

Relates:

### Description 📝
There was an issue when upgrading to version 1.32.0 in the OnPremises provider when gatekeeper was enabled. This PR makes an effort to document that.

### Breaking Changes 💔
None.

### Tests performed 🧪
None.

### Future work 🔧
None.
