### PR TITLE
fix(ansible): stdout_callback deprecation warning

### DIFF
--- a/templates/kubernetes/onpremises/ansible.cfg.tpl
+++ b/templates/kubernetes/onpremises/ansible.cfg.tpl
@@ -7,7 +7,7 @@ inventory = hosts.yaml
 host_key_checking = False
 roles_path = ../vendor/installers/onpremises/roles
 timeout = 90
-stdout_callback = yaml
+callback_result_format = yaml
 bin_ansible_callbacks = True
 {{- if and (index .spec.kubernetes "advancedAnsible") (index .spec.kubernetes.advancedAnsible "config") }}
 {{ .spec.kubernetes.advancedAnsible.config }}

--- a/templates/preflight/onpremises/ansible.cfg.tpl
+++ b/templates/preflight/onpremises/ansible.cfg.tpl
@@ -7,7 +7,7 @@ inventory = hosts.yaml
 host_key_checking = False
 roles_path = ../vendor/installers/onpremises/roles
 timeout = 90
-stdout_callback = yaml
+callback_result_format = yaml
 bin_ansible_callbacks = True
 {{- if and (index .spec.kubernetes "advancedAnsible") (index .spec.kubernetes.advancedAnsible "config") }}
 {{ .spec.kubernetes.advancedAnsible.config }}

--- a/templates/preflight/onpremises/verify-playbook.yaml
+++ b/templates/preflight/onpremises/verify-playbook.yaml
@@ -18,7 +18,7 @@
         dest: "{{ kubernetes_kubeconfig_path }}/admin.conf"
         flat: yes
       when: admin_conf_stat.stat.exists
-            
+
     - name: Set fact if admin.conf exists
       set_fact:
         admin_conf_exists: "{{ admin_conf_stat.stat.exists }}"

--- a/tests/e2e/onpremises-upgrades/ansible.cfg
+++ b/tests/e2e/onpremises-upgrades/ansible.cfg
@@ -7,6 +7,6 @@ inventory = hosts.yaml
 host_key_checking = False
 roles_path = ./roles
 timeout = 90
-stdout_callback = yaml
+callback_result_format = yaml
 bin_ansible_callbacks = True
 

--- a/tests/e2e/onpremises/ansible.cfg
+++ b/tests/e2e/onpremises/ansible.cfg
@@ -7,6 +7,6 @@ inventory = hosts.yaml
 host_key_checking = False
 roles_path = ./roles
 timeout = 90
-stdout_callback = yaml
+callback_result_format = yaml
 bin_ansible_callbacks = True
 


### PR DESCRIPTION
### Summary 💡

Solve a deprecation warning in furyctl logs when running Ansible playbooks.

### Description 📝

Solve a deprecation warning when using stdout_callback=yaml. This option has been deprecated in from ansible-core 2.13 onwards and replaced by callback_result_format=yaml. The stdout_callback option will be removed from community.general in version 12.0.0 (current latest is 11.0.0).

Current latest version of ansible-core is 2.18 and the ansible-core included in Debian 12 (one of the most coservative distros) is 2.14.18.

The deprecation warning looks as follows:

```
[DEPRECATION WARNING]: community.general.yaml has been deprecated. The plugin
has been superseded by the the option `result_format=yaml` in callback plugin
ansible.builtin.default from ansible-core 2.13 onwards. This feature will be
removed from community.general in version 12.0.0. Deprecation warnings can be
disabled by setting deprecation_warnings=False in ansible.cfg.
```

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested the change with SD version 1.32.0

### Future work 🔧

None