### PR TITLE
feat(logging): allow to set Fluentd and Fluentbit's resouces

### DIFF
--- a/defaults/ekscluster-kfd-v1alpha2.yaml
+++ b/defaults/ekscluster-kfd-v1alpha2.yaml
@@ -92,6 +92,9 @@ data:
             disableAuth: false
             host: ""
             ingressClass: ""
+      operator:
+        fluentd: {}
+        fluentbit: {}
       # can be none, opensearch, loki or customOutputs
       type: opensearch
       opensearch:

--- a/defaults/kfddistribution-kfd-v1alpha2.yaml
+++ b/defaults/kfddistribution-kfd-v1alpha2.yaml
@@ -85,6 +85,9 @@ data:
             disableAuth: false
             host: ""
             ingressClass: ""
+      operator:
+        fluentd: {}
+        fluentbit: {}
       # can be none, opensearch, loki or customOutputs
       type: opensearch
       opensearch:

--- a/defaults/onpremises-kfd-v1alpha2.yaml
+++ b/defaults/onpremises-kfd-v1alpha2.yaml
@@ -85,6 +85,9 @@ data:
             disableAuth: false
             host: ""
             ingressClass: ""
+      operator:
+        fluentd: {}
+        fluentbit: {}
       # can be none, opensearch, loki or customOutputs
       type: opensearch
       opensearch:

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -27,7 +27,7 @@ This version adds customizations to make it easier to install SD on bare metal n
               podCidr: 172.16.0.0/16
     ```
 
-  - `kernelParameters` to the `.spec.kubernetes.advanced`, `.spec.kubernetes.masters` and `-spec.kubernetes.nodes[]` sections, to allow customization of kernel parameters of each Kubernetes node. Example:
+  - `kernelParameters` to the `.spec.kubernetes.advanced`, `.spec.kubernetes.masters` and `.spec.kubernetes.nodes[]` sections, to allow customization of kernel parameters of each Kubernetes node. Example:
 
     ```yaml
     spec:
@@ -51,7 +51,7 @@ This version adds customizations to make it easier to install SD on bare metal n
             oidcTrustedCA: "{file://my-ca.crt}"
     ```
 
-- [[[#428](https://github.com/sighupio/distribution/issues/428)]] Configuration for Logging Operator's Fluentd and Fluentbit resources:
+- [[#428](https://github.com/sighupio/distribution/issues/428)] Configuration for Logging Operator's Fluentd and Fluentbit resources:
   - Added new configuration options to the logging module that allows to set Fluentd's resources and replicas number and Fluentbit's resources. Example:
   
   ```yaml

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -12,7 +12,7 @@ This version adds customizations to make it easier to install SD on bare metal n
 
 ## New features 🌟
 
-- [[#415](https://github.com/sighupio/distribution/pull/415)]: Adds customizations to make it easier to install SD on bare metal nodes:
+- [[#415](https://github.com/sighupio/distribution/pull/415)] Adds customizations to make it easier to install SD on bare metal nodes:
   - `blockSize` and `podCidr` to the `spec.distribution.modules.networking.tigeraOperator` section of the OnPremises and KFDDistribution schemas, allowing customizations to the assigned CIDR for each node.
   How to use it:
 
@@ -38,7 +38,7 @@ This version adds customizations to make it easier to install SD on bare metal n
             value: "9223372036854775804"
     ```
 
-- [[#425](https://github.com/sighupio/distribution/pull/425)]: Adds trusted CA certificate support in OIDC authentication with self-signed certificates:
+- [[#425](https://github.com/sighupio/distribution/pull/425)] Adds trusted CA certificate support in OIDC authentication with self-signed certificates:
   - `oidcTrustedCA` key under `spec.distribution.modules.auth` allows automatic provisioning of custom CA certificates for auth components.
   - Adds secret generation and volume mounting for Gangplank, Pomerium, and Dex deployments.
   - Supports `{file://path}` notation.
@@ -51,8 +51,29 @@ This version adds customizations to make it easier to install SD on bare metal n
             oidcTrustedCA: "{file://my-ca.crt}"
     ```
 
+- [[[#428](https://github.com/sighupio/distribution/issues/428)]] Configuration for Logging Operator's Fluentd and Fluentbit resources:
+  - Added new configuration options to the logging module that allows to set Fluentd's resources and replicas number and Fluentbit's resources. Example:
+  
+  ```yaml
+  spec:
+    distribution:
+      modules:
+        logging:
+          operator:
+            fluentd:
+              replicas: 1
+                resources:
+                  limits:
+                    cpu: "2500m"
+            fluentbit:
+              resources:
+                requests:
+                  memory: "1Mi"
+  ```
+
 ## Fixes 🐞
-- [/installer-eks/issues#88](https://github.com/sighupio/installer-eks/issues/88) This PR fixes an issue when using `selfmanaged` nodes with `alinux2023`. The way we used to provision images relied on amazon's `bootstrap.sh` which has been deprecated in favor of nodeadm.
+
+- [installer-eks/issues#88](https://github.com/sighupio/installer-eks/issues/88) This PR fixes an issue when using `selfmanaged` nodes with `alinux2023`. The way we used to provision images relied on Amazon's `bootstrap.sh` which has been deprecated in favor of `nodeadm`.
 
 ### Security fixes
 

--- a/docs/schemas/onpremises-kfd-v1alpha2.md
+++ b/docs/schemas/onpremises-kfd-v1alpha2.md
@@ -2671,11 +2671,146 @@ The type of OpenSearch deployment. One of: `single` for a single replica or `tri
 
 | Property                                                      | Type     | Required |
 |:--------------------------------------------------------------|:---------|:---------|
+| [fluentbit](#specdistributionmodulesloggingoperatorfluentbit) | `object` | Optional |
+| [fluentd](#specdistributionmodulesloggingoperatorfluentd)     | `object` | Optional |
 | [overrides](#specdistributionmodulesloggingoperatoroverrides) | `object` | Optional |
 
 ### Description
 
 Configuration for the Logging Operator.
+
+## .spec.distribution.modules.logging.operator.fluentbit
+
+### Properties
+
+| Property                                                               | Type     | Required |
+|:-----------------------------------------------------------------------|:---------|:---------|
+| [resources](#specdistributionmodulesloggingoperatorfluentbitresources) | `object` | Optional |
+
+### Description
+
+Configuration for Fluent Bit that reads the logs from the workload and forwards them to Fluentd.
+
+## .spec.distribution.modules.logging.operator.fluentbit.resources
+
+### Properties
+
+| Property                                                                      | Type     | Required |
+|:------------------------------------------------------------------------------|:---------|:---------|
+| [limits](#specdistributionmodulesloggingoperatorfluentbitresourceslimits)     | `object` | Optional |
+| [requests](#specdistributionmodulesloggingoperatorfluentbitresourcesrequests) | `object` | Optional |
+
+## .spec.distribution.modules.logging.operator.fluentbit.resources.limits
+
+### Properties
+
+| Property                                                                        | Type     | Required |
+|:--------------------------------------------------------------------------------|:---------|:---------|
+| [cpu](#specdistributionmodulesloggingoperatorfluentbitresourceslimitscpu)       | `string` | Optional |
+| [memory](#specdistributionmodulesloggingoperatorfluentbitresourceslimitsmemory) | `string` | Optional |
+
+## .spec.distribution.modules.logging.operator.fluentbit.resources.limits.cpu
+
+### Description
+
+The CPU limit for the Pod. Example: `1000m`.
+
+## .spec.distribution.modules.logging.operator.fluentbit.resources.limits.memory
+
+### Description
+
+The memory limit for the Pod. Example: `1G`.
+
+## .spec.distribution.modules.logging.operator.fluentbit.resources.requests
+
+### Properties
+
+| Property                                                                          | Type     | Required |
+|:----------------------------------------------------------------------------------|:---------|:---------|
+| [cpu](#specdistributionmodulesloggingoperatorfluentbitresourcesrequestscpu)       | `string` | Optional |
+| [memory](#specdistributionmodulesloggingoperatorfluentbitresourcesrequestsmemory) | `string` | Optional |
+
+## .spec.distribution.modules.logging.operator.fluentbit.resources.requests.cpu
+
+### Description
+
+The CPU request for the Pod, in cores. Example: `500m`.
+
+## .spec.distribution.modules.logging.operator.fluentbit.resources.requests.memory
+
+### Description
+
+The memory request for the Pod. Example: `500M`.
+
+## .spec.distribution.modules.logging.operator.fluentd
+
+### Properties
+
+| Property                                                             | Type      | Required |
+|:---------------------------------------------------------------------|:----------|:---------|
+| [replicas](#specdistributionmodulesloggingoperatorfluentdreplicas)   | `integer` | Optional |
+| [resources](#specdistributionmodulesloggingoperatorfluentdresources) | `object`  | Optional |
+
+### Description
+
+Configuration for Fluentd that collects the logs and forwards them to the outputs.
+
+## .spec.distribution.modules.logging.operator.fluentd.replicas
+
+### Description
+
+The number of Fluentd replicas to run. Default is `2`.
+
+## .spec.distribution.modules.logging.operator.fluentd.resources
+
+### Properties
+
+| Property                                                                    | Type     | Required |
+|:----------------------------------------------------------------------------|:---------|:---------|
+| [limits](#specdistributionmodulesloggingoperatorfluentdresourceslimits)     | `object` | Optional |
+| [requests](#specdistributionmodulesloggingoperatorfluentdresourcesrequests) | `object` | Optional |
+
+## .spec.distribution.modules.logging.operator.fluentd.resources.limits
+
+### Properties
+
+| Property                                                                      | Type     | Required |
+|:------------------------------------------------------------------------------|:---------|:---------|
+| [cpu](#specdistributionmodulesloggingoperatorfluentdresourceslimitscpu)       | `string` | Optional |
+| [memory](#specdistributionmodulesloggingoperatorfluentdresourceslimitsmemory) | `string` | Optional |
+
+## .spec.distribution.modules.logging.operator.fluentd.resources.limits.cpu
+
+### Description
+
+The CPU limit for the Pod. Example: `1000m`.
+
+## .spec.distribution.modules.logging.operator.fluentd.resources.limits.memory
+
+### Description
+
+The memory limit for the Pod. Example: `1G`.
+
+## .spec.distribution.modules.logging.operator.fluentd.resources.requests
+
+### Properties
+
+| Property                                                                        | Type     | Required |
+|:--------------------------------------------------------------------------------|:---------|:---------|
+| [cpu](#specdistributionmodulesloggingoperatorfluentdresourcesrequestscpu)       | `string` | Optional |
+| [memory](#specdistributionmodulesloggingoperatorfluentdresourcesrequestsmemory) | `string` | Optional |
+
+## .spec.distribution.modules.logging.operator.fluentd.resources.requests.cpu
+
+### Description
+
+The CPU request for the Pod, in cores. Example: `500m`.
+
+## .spec.distribution.modules.logging.operator.fluentd.resources.requests.memory
+
+### Description
+
+The memory request for the Pod. Example: `500M`.
 
 ## .spec.distribution.modules.logging.operator.overrides
 

--- a/pkg/apis/onpremises/v1alpha2/public/schema.go
+++ b/pkg/apis/onpremises/v1alpha2/public/schema.go
@@ -1156,8 +1156,33 @@ const (
 
 // Configuration for the Logging Operator.
 type SpecDistributionModulesLoggingOperator struct {
+	// Configuration for Fluent Bit that reads the logs from the workload and forwards
+	// them to Fluentd.
+	Fluentbit *SpecDistributionModulesLoggingOperatorFluentbit `json:"fluentbit,omitempty" yaml:"fluentbit,omitempty" mapstructure:"fluentbit,omitempty"`
+
+	// Configuration for Fluentd that collects the logs and forwards them to the
+	// outputs.
+	Fluentd *SpecDistributionModulesLoggingOperatorFluentd `json:"fluentd,omitempty" yaml:"fluentd,omitempty" mapstructure:"fluentd,omitempty"`
+
 	// Overrides corresponds to the JSON schema field "overrides".
 	Overrides *TypesFuryModuleComponentOverrides `json:"overrides,omitempty" yaml:"overrides,omitempty" mapstructure:"overrides,omitempty"`
+}
+
+// Configuration for Fluent Bit that reads the logs from the workload and forwards
+// them to Fluentd.
+type SpecDistributionModulesLoggingOperatorFluentbit struct {
+	// Resources corresponds to the JSON schema field "resources".
+	Resources *TypesKubeResources `json:"resources,omitempty" yaml:"resources,omitempty" mapstructure:"resources,omitempty"`
+}
+
+// Configuration for Fluentd that collects the logs and forwards them to the
+// outputs.
+type SpecDistributionModulesLoggingOperatorFluentd struct {
+	// The number of Fluentd replicas to run. Default is `2`.
+	Replicas *int `json:"replicas,omitempty" yaml:"replicas,omitempty" mapstructure:"replicas,omitempty"`
+
+	// Resources corresponds to the JSON schema field "resources".
+	Resources *TypesKubeResources `json:"resources,omitempty" yaml:"resources,omitempty" mapstructure:"resources,omitempty"`
 }
 
 type SpecDistributionModulesLoggingType string
@@ -1319,20 +1344,22 @@ func (j *SpecDistributionModulesTracingType) UnmarshalJSON(b []byte) error {
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *SpecDistributionModulesIngressNginx) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
+func (j *SpecDistributionModulesIngressNginxType) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}
-	if v, ok := raw["type"]; !ok || v == nil {
-		return fmt.Errorf("field type in SpecDistributionModulesIngressNginx: required")
+	var ok bool
+	for _, expected := range enumValues_SpecDistributionModulesIngressNginxType {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
 	}
-	type Plain SpecDistributionModulesIngressNginx
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_SpecDistributionModulesIngressNginxType, v)
 	}
-	*j = SpecDistributionModulesIngressNginx(plain)
+	*j = SpecDistributionModulesIngressNginxType(v)
 	return nil
 }
 
@@ -1340,6 +1367,27 @@ var enumValues_SpecDistributionModulesIngressNginxType = []interface{}{
 	"none",
 	"single",
 	"dual",
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *SpecDistributionModulesIngress) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["baseDomain"]; !ok || v == nil {
+		return fmt.Errorf("field baseDomain in SpecDistributionModulesIngress: required")
+	}
+	if v, ok := raw["nginx"]; !ok || v == nil {
+		return fmt.Errorf("field nginx in SpecDistributionModulesIngress: required")
+	}
+	type Plain SpecDistributionModulesIngress
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = SpecDistributionModulesIngress(plain)
+	return nil
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -1385,53 +1433,6 @@ func (j *SpecDistributionModulesIngressNginxTLSSecret) UnmarshalJSON(b []byte) e
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *SpecDistributionModulesIngress) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["baseDomain"]; !ok || v == nil {
-		return fmt.Errorf("field baseDomain in SpecDistributionModulesIngress: required")
-	}
-	if v, ok := raw["nginx"]; !ok || v == nil {
-		return fmt.Errorf("field nginx in SpecDistributionModulesIngress: required")
-	}
-	type Plain SpecDistributionModulesIngress
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = SpecDistributionModulesIngress(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *SpecDistributionModulesIngressNginxTLSProvider) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_SpecDistributionModulesIngressNginxTLSProvider {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_SpecDistributionModulesIngressNginxTLSProvider, v)
-	}
-	*j = SpecDistributionModulesIngressNginxTLSProvider(v)
-	return nil
-}
-
-var enumValues_SpecDistributionModulesIngressNginxTLSProvider = []interface{}{
-	"certManager",
-	"secret",
-	"none",
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
 func (j *SpecDistributionModulesLoggingCustomOutputs) UnmarshalJSON(b []byte) error {
 	var raw map[string]interface{}
 	if err := json.Unmarshal(b, &raw); err != nil {
@@ -1471,20 +1472,22 @@ func (j *SpecDistributionModulesLoggingCustomOutputs) UnmarshalJSON(b []byte) er
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *SpecDistributionModulesIngressCertManager) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
+func (j *SpecDistributionModulesIngressNginxTLSProvider) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}
-	if v, ok := raw["clusterIssuer"]; !ok || v == nil {
-		return fmt.Errorf("field clusterIssuer in SpecDistributionModulesIngressCertManager: required")
+	var ok bool
+	for _, expected := range enumValues_SpecDistributionModulesIngressNginxTLSProvider {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
 	}
-	type Plain SpecDistributionModulesIngressCertManager
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_SpecDistributionModulesIngressNginxTLSProvider, v)
 	}
-	*j = SpecDistributionModulesIngressCertManager(plain)
+	*j = SpecDistributionModulesIngressNginxTLSProvider(v)
 	return nil
 }
 
@@ -1513,6 +1516,30 @@ func (j *SpecDistributionModulesLoggingLokiBackend) UnmarshalJSON(b []byte) erro
 	return nil
 }
 
+var enumValues_SpecDistributionModulesIngressNginxTLSProvider = []interface{}{
+	"certManager",
+	"secret",
+	"none",
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *SpecDistributionModulesIngressCertManager) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["clusterIssuer"]; !ok || v == nil {
+		return fmt.Errorf("field clusterIssuer in SpecDistributionModulesIngressCertManager: required")
+	}
+	type Plain SpecDistributionModulesIngressCertManager
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = SpecDistributionModulesIngressCertManager(plain)
+	return nil
+}
+
 // UnmarshalJSON implements json.Unmarshaler.
 func (j *SpecDistributionModulesIngressCertManagerClusterIssuer) UnmarshalJSON(b []byte) error {
 	var raw map[string]interface{}
@@ -1532,30 +1559,6 @@ func (j *SpecDistributionModulesIngressCertManagerClusterIssuer) UnmarshalJSON(b
 	}
 	*j = SpecDistributionModulesIngressCertManagerClusterIssuer(plain)
 	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *SpecDistributionModulesIngressCertManagerClusterIssuerType) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_SpecDistributionModulesIngressCertManagerClusterIssuerType {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_SpecDistributionModulesIngressCertManagerClusterIssuerType, v)
-	}
-	*j = SpecDistributionModulesIngressCertManagerClusterIssuerType(v)
-	return nil
-}
-
-var enumValues_SpecDistributionModulesIngressCertManagerClusterIssuerType = []interface{}{
-	"http01",
 }
 
 type TypesKubeResourcesLimits struct {
@@ -1580,6 +1583,30 @@ type TypesKubeResources struct {
 
 	// Requests corresponds to the JSON schema field "requests".
 	Requests *TypesKubeResourcesRequests `json:"requests,omitempty" yaml:"requests,omitempty" mapstructure:"requests,omitempty"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *SpecDistributionModulesIngressCertManagerClusterIssuerType) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_SpecDistributionModulesIngressCertManagerClusterIssuerType {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_SpecDistributionModulesIngressCertManagerClusterIssuerType, v)
+	}
+	*j = SpecDistributionModulesIngressCertManagerClusterIssuerType(v)
+	return nil
+}
+
+var enumValues_SpecDistributionModulesIngressCertManagerClusterIssuerType = []interface{}{
+	"http01",
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -1620,31 +1647,6 @@ func (j *SpecDistributionModulesDrVeleroBackend) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-var enumValues_SpecDistributionModulesDrVeleroBackend = []interface{}{
-	"minio",
-	"externalEndpoint",
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *SpecDistributionModulesDrType) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_SpecDistributionModulesDrType {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_SpecDistributionModulesDrType, v)
-	}
-	*j = SpecDistributionModulesDrType(v)
-	return nil
-}
-
 var enumValues_SpecDistributionModulesLoggingOpensearchType = []interface{}{
 	"single",
 	"triple",
@@ -1670,25 +1672,35 @@ func (j *SpecDistributionModulesLoggingOpensearchType) UnmarshalJSON(b []byte) e
 	return nil
 }
 
+var enumValues_SpecDistributionModulesDrVeleroBackend = []interface{}{
+	"minio",
+	"externalEndpoint",
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *SpecDistributionModulesDrType) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_SpecDistributionModulesDrType {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_SpecDistributionModulesDrType, v)
+	}
+	*j = SpecDistributionModulesDrType(v)
+	return nil
+}
+
 var enumValues_SpecDistributionModulesDrType = []interface{}{
 	"none",
 	"on-premises",
 }
-
-// Override the common configuration with a particular configuration for the
-// module.
-type TypesFuryModuleOverrides struct {
-	// Ingresses corresponds to the JSON schema field "ingresses".
-	Ingresses TypesFuryModuleOverridesIngresses `json:"ingresses,omitempty" yaml:"ingresses,omitempty" mapstructure:"ingresses,omitempty"`
-
-	// Set to override the node selector used to place the pods of the module.
-	NodeSelector TypesKubeNodeSelector `json:"nodeSelector,omitempty" yaml:"nodeSelector,omitempty" mapstructure:"nodeSelector,omitempty"`
-
-	// Set to override the tolerations that will be added to the pods of the module.
-	Tolerations []TypesKubeToleration `json:"tolerations,omitempty" yaml:"tolerations,omitempty" mapstructure:"tolerations,omitempty"`
-}
-
-type TypesFuryModuleOverridesIngresses map[string]TypesFuryModuleOverridesIngress
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (j *SpecDistributionModulesLoggingOpensearch) UnmarshalJSON(b []byte) error {
@@ -1707,6 +1719,21 @@ func (j *SpecDistributionModulesLoggingOpensearch) UnmarshalJSON(b []byte) error
 	*j = SpecDistributionModulesLoggingOpensearch(plain)
 	return nil
 }
+
+// Override the common configuration with a particular configuration for the
+// module.
+type TypesFuryModuleOverrides struct {
+	// Ingresses corresponds to the JSON schema field "ingresses".
+	Ingresses TypesFuryModuleOverridesIngresses `json:"ingresses,omitempty" yaml:"ingresses,omitempty" mapstructure:"ingresses,omitempty"`
+
+	// Set to override the node selector used to place the pods of the module.
+	NodeSelector TypesKubeNodeSelector `json:"nodeSelector,omitempty" yaml:"nodeSelector,omitempty" mapstructure:"nodeSelector,omitempty"`
+
+	// Set to override the tolerations that will be added to the pods of the module.
+	Tolerations []TypesKubeToleration `json:"tolerations,omitempty" yaml:"tolerations,omitempty" mapstructure:"tolerations,omitempty"`
+}
+
+type TypesFuryModuleOverridesIngresses map[string]TypesFuryModuleOverridesIngress
 
 type TypesFuryModuleOverridesIngress struct {
 	// If true, the ingress will not have authentication even if
@@ -2586,22 +2613,20 @@ var enumValues_SpecDistributionModulesTracingType = []interface{}{
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *SpecDistributionModulesIngressNginxType) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
+func (j *SpecDistributionModulesIngressNginx) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
 		return err
 	}
-	var ok bool
-	for _, expected := range enumValues_SpecDistributionModulesIngressNginxType {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
+	if v, ok := raw["type"]; !ok || v == nil {
+		return fmt.Errorf("field type in SpecDistributionModulesIngressNginx: required")
 	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_SpecDistributionModulesIngressNginxType, v)
+	type Plain SpecDistributionModulesIngressNginx
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
 	}
-	*j = SpecDistributionModulesIngressNginxType(v)
+	*j = SpecDistributionModulesIngressNginx(plain)
 	return nil
 }
 

--- a/schemas/public/onpremises-kfd-v1alpha2.json
+++ b/schemas/public/onpremises-kfd-v1alpha2.json
@@ -1282,6 +1282,30 @@
       "additionalProperties": false,
       "description": "Configuration for the Logging Operator.",
       "properties": {
+        "fluentd": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Configuration for Fluentd that collects the logs and forwards them to the outputs.",
+          "properties": {
+            "replicas": {
+              "type": "integer",
+              "description": "The number of Fluentd replicas to run. Default is `2`."
+            },
+            "resources": {
+              "$ref": "#/$defs/Types.KubeResources"
+            }
+          }
+        },
+        "fluentbit": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Configuration for Fluent Bit that reads the logs from the workload and forwards them to Fluentd.",
+          "properties": {
+            "resources": {
+              "$ref": "#/$defs/Types.KubeResources"
+            }
+          }
+        },
         "overrides": {
           "$ref": "#/$defs/Types.FuryModuleComponentOverrides"
         }

--- a/templates/distribution/manifests/logging/kustomization.yaml.tpl
+++ b/templates/distribution/manifests/logging/kustomization.yaml.tpl
@@ -6,19 +6,23 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-{{ $loggingType := .spec.distribution.modules.logging.type }}
-{{ $customOutputs := .spec.distribution.modules.logging.customOutputs }}
+{{- $loggingType := .spec.distribution.modules.logging.type }}
+{{- $customOutputs := .spec.distribution.modules.logging.customOutputs }}
+{{- $loki := index .spec.distribution.modules.logging "loki" }}
+{{- $fluentdReplicas := index .spec.distribution.modules.logging.operator.fluentd "replicas" }}
+{{- $fluentdResources := index .spec.distribution.modules.logging.operator.fluentd "resources" }}
+{{- $fluentbitResources := index .spec.distribution.modules.logging.operator.fluentbit "resources" }}
 
 resources:
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/logging/katalog/logging-operator" }}
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/logging/katalog/logging-operated" }}
-{{- if or (eq $loggingType "loki") (eq $loggingType "opensearch") }}
+{{- if eq $loggingType "loki" "opensearch" }}
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/logging/katalog/minio-ha" }}
   {{- if ne .spec.distribution.modules.ingress.nginx.type "none" }}
   - resources/ingress-infra.yml
   {{- end }}
 {{- end }}
-{{- if or (eq $loggingType "opensearch") (eq $loggingType "customOutputs") }}
+{{- if eq $loggingType "opensearch" "customOutputs" }}
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/logging/katalog/configs/audit" }}
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/logging/katalog/configs/events" }}
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/logging/katalog/configs/infra" }}
@@ -47,31 +51,25 @@ resources:
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/logging/katalog/loki-distributed" }}
 {{- end }}
 
-{{ if eq .spec.distribution.common.networkPoliciesEnabled true }}
+{{- if eq .spec.distribution.common.networkPoliciesEnabled true }}
   - policies
 {{- end }}
 
-# The kustomize version we are using does not support specifing more than 1 strategicMerge patch
-# in a single YAML file under the `patches` directive like the old versions did for `patchesStrategicMerge`.
-# Until the fix is released and we switch to that version we can't move this under the `patch` directive.
-# Refs:
-# - https://github.com/kubernetes-sigs/kustomize/issues/5049
-# - https://github.com/kubernetes-sigs/kustomize/pull/5194
-# A workaround would be to split the infra-nodes.yml file into several files (one per patch).
-patchesStrategicMerge:
-  - patches/infra-nodes.yml
-{{- if or (eq $loggingType "opensearch") (eq $loggingType "loki") }}
-  - patches/minio.yml
+patches:
+  - path: patches/infra-nodes.yml
+{{- if or $fluentdReplicas $fluentdResources $fluentbitResources }}
+  - path: patches/logging-operated-resources.yaml
+{{- end }}
+{{- if eq $loggingType "opensearch" "loki" }}
+  - path: patches/minio.yml
   {{- if eq $loggingType "opensearch" }}
-  - patches/opensearch.yml
-  {{- else }}
-  - patches/loki.yml
+  - path: patches/opensearch.yml
+  {{- /* The patch file below can be empty when loki resources is not defined but kustomize 5.6.0 (our current version) fails when a patch file is empty, so we need to apply it conditionally. */ -}}
+  {{- else if hasKeyAny $loki "resources" }}
+  - path: patches/loki-resources.yml
   {{- end }}
 {{- end }}
-
-{{- if or (eq $loggingType "customOutputs") (eq .spec.distribution.modules.monitoring.type "none") }}
-patches:
-  {{- if eq $loggingType "customOutputs" }}
+{{- if eq $loggingType "customOutputs" }}
   - target:
       kind: Output
       group: logging.banzaicloud.io
@@ -152,8 +150,8 @@ patches:
         path: /spec
         value:
 {{ $customOutputs.errors | indent 10 }}
-  {{- end }}
-  {{- if eq .spec.distribution.modules.monitoring.type "none" }}
+{{- end }}
+{{- if eq .spec.distribution.modules.monitoring.type "none" }}
   - patch: |-
       apiVersion: logging.banzaicloud.io/v1beta1
       kind: Logging
@@ -164,11 +162,10 @@ patches:
           metrics:
             serviceMonitor: false
             prometheusRules: false
-  {{- end }}
 {{- end }}
 
 
-{{- if or (eq $loggingType "opensearch") (eq $loggingType "loki") }}
+{{- if eq $loggingType "opensearch" "loki" }}
 secretGenerator:
   {{- if eq $loggingType "loki" }}
   - name: loki

--- a/templates/distribution/manifests/logging/patches/logging-operated-resources.yaml.tpl
+++ b/templates/distribution/manifests/logging/patches/logging-operated-resources.yaml.tpl
@@ -1,0 +1,32 @@
+{{- $fluentdReplicas := index .spec.distribution.modules.logging.operator.fluentd "replicas" }}
+{{- $fluentdResources := index .spec.distribution.modules.logging.operator.fluentd "resources" }}
+{{- $fluentbitResources := index .spec.distribution.modules.logging.operator.fluentbit "resources" }}
+
+{{- if or $fluentdReplicas $fluentdResources }}
+---
+apiVersion: logging.banzaicloud.io/v1beta1
+kind: Logging
+metadata:
+  name: infra
+spec:
+  fluentd:
+    {{- if $fluentdReplicas }}
+    scaling:
+      replicas: {{ $fluentdReplicas }}
+    {{- end }}
+    {{- if $fluentdResources }}
+    resources:
+{{ $fluentdResources | toYaml | indent 6 }}
+    {{- end }}
+{{- end }}
+
+{{- if $fluentbitResources }}
+---
+apiVersion: logging.banzaicloud.io/v1beta1
+kind: FluentbitAgent
+metadata:
+  name: infra
+spec:
+  resources:
+{{ $fluentbitResources | toYaml | indent 6 }}
+{{- end }}

--- a/templates/distribution/manifests/logging/patches/loki-resources.yml.tpl
+++ b/templates/distribution/manifests/logging/patches/loki-resources.yml.tpl
@@ -1,7 +1,3 @@
-# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
-# Use of this source code is governed by a BSD-style
-# license that can be found in the LICENSE file.
-
 {{- $package := index .spec.distribution.modules.logging "loki" -}}
 
 {{- if and (eq .spec.distribution.modules.logging.type "loki") (hasKeyAny $package "resources") }}


### PR DESCRIPTION
### Summary 💡

- Add configuration fields to the schemas to allow setting resources to Logging Operator's Fluentd and Fluentbit.
- Add configuration field to set Logging Operator's Fluentd replica count.
- Adjust templates to use the new fields.
- Update logging's kustomization.yaml file to use `patches` and drop deprecated syntax. Make logic a little clearer (hopefully)
- Update related documentation.

Relates:
- https://github.com/sighupio/module-logging/pull/191 

### Description 📝

We've seen lately that for production clusters the defaults were not enough and patching the resources requests and specially limits for the loggging stack components was a common use case.

This PR adds missing parameters to configure the logging stack from the furyctl.yaml file, under the `spec.distribution.modules.logging.operator` key, one for fluentd and one for fluentbit.

Example:

```yaml
spec:
  distritbution:
    modules:
      logging:
        type: loki
        operator:
          fluentd:
            replicas: 1
            resources:
              limits:
                cpu: "10000m"
          fluentbit:
            resources:
              requests:
                memory: 1M
...
```

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested using `main` version of the distro and pointing to the `feat/increase-default-resources` branch of the Logging module (that includes the new default values).
- [x] Tested NOT setting any of the new parameters and verified that the templates still work as expected and there are no errors of undefined keys, for example.
- [x] Tested with type Loki and setting fluentd replicas, requests and limits and fluentbit request and limits and several combinations of these options.
- [x] Tested with type OpenSearch and setting fluentd replicas, requests and limits and fluentbit request and limits and several combinations of these options.

### Future work 🔧

I considered adding also parameters to patch the **flush thread count** for the Outputs, but I decided to leave it for future PRs because:

1. We've bumped the default values (see related PR) for this parameter in the logging module
2. Configuration would became a little messy because we would need to add a key for each output, another option would be having a common value for all of the (cluster)Outputs.

IMO we can wait to see if the new default values cover most of the cases and then decide if we still need to expose that parameter.