### PR TITLE
fix(schemas): validate kustomize plugin names pattern

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -97,6 +97,8 @@ This version adds customizations to make it easier to install SD on bare metal n
 
 - [installer-eks/issues#88](https://github.com/sighupio/installer-eks/issues/88) This PR fixes an issue when using `selfmanaged` nodes with `alinux2023`. The way we used to provision images relied on Amazon's `bootstrap.sh` which has been deprecated in favor of `nodeadm`.
 
+- Plugins names are now pattern-validated in the schema to avoid potential errors at runtime when setting invalid names.
+
 ### Security fixes
 
 ## Upgrade procedure

--- a/schemas/public/spec-plugins.json
+++ b/schemas/public/spec-plugins.json
@@ -38,7 +38,10 @@
             "description": "The url of the repository"
           }
         },
-        "required": ["name", "url"]
+        "required": [
+          "name",
+          "url"
+        ]
       }
     },
     "Spec.Plugins.Helm.Releases": {
@@ -78,7 +81,10 @@
                   "description": "The value of the set"
                 }
               },
-              "required": ["name", "value"]
+              "required": [
+                "name",
+                "value"
+              ]
             }
           },
           "values": {
@@ -93,7 +99,11 @@
             "description": "Disable running `helm diff` validation when installing the plugin, it will still be done when upgrading."
           }
         },
-        "required": ["name", "namespace", "chart"]
+        "required": [
+          "name",
+          "namespace",
+          "chart"
+        ]
       }
     },
     "Spec.Plugins.Kustomize": {
@@ -104,14 +114,18 @@
         "properties": {
           "name": {
             "type": "string",
-            "description": "The name of the kustomize plugin"
+            "description": "The name of the kustomize plugin. A lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', 'local-storage')",
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
           },
           "folder": {
             "type": "string",
             "description": "The folder of the kustomize plugin"
           }
         },
-        "required": ["name", "folder"]
+        "required": [
+          "name",
+          "folder"
+        ]
       }
     }
   }


### PR DESCRIPTION
### Summary 💡

Validate kustomize plugins name pattern with what kapp expects at schema level so errors are catch soon and avoid runtime errors after a (maybe long) apply.

### Description 📝

See summary.

Note: linting failures are unrelated to this PR.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested the change with SD version 1.32.1-rc.2, validated that correct names pass and wrong names are catch early.

### Future work 🔧

None
