### PR TITLE
fix(terraform): missing tags variable assignment in ekscluster template

### DIFF
--- a/templates/kubernetes/ekscluster/terraform/main.auto.tfvars.tpl
+++ b/templates/kubernetes/ekscluster/terraform/main.auto.tfvars.tpl
@@ -5,6 +5,11 @@
  */
 
 cluster_name = {{ .metadata.name | quote }}
+tags = {
+{{- range $key, $value := .spec.tags }}
+  {{ $key }} = "{{ $value }}"
+{{- end }}
+}
 
 {{- if hasKeyAny .spec.kubernetes "logsTypes" }}
 cluster_enabled_log_types = {{ toJson .spec.kubernetes.logsTypes }}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request.

By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull
request to the best possible team for review.

💡 **TIP**
Remember that you can always open a PR in draft status and fill all the information afterwards.

Opening a PR in draft allows other team members to know that you are working on this change, and let's you have a
place to track your work in progress.

When opening PRs in Draft, **don't assign reviewers until the PR is ready for review**.

Once you are confortable with the status of the PR and all the tests and CI is green, you can assign the reviewers to start the review process.
-->

### Summary 💡

Fix missing tags variable assignment in EKS cluster Terraform template causing resources to be created without proper tagging.

<!--
If there's an existing issue for your change, please link to it below inserting a link or the issue number.

If there's _not_ an existing issue, please open one first if the problem you are solving needs to be clearly identified,
for example is an error message that other users could get and google it.
-->
Closes: [sighupio/product-management/issues/662](https://github.com/sighupio/product-management/issues/662)

### Description 📝

Fixes a bug where the `tags` variable was defined in `variables.tf` and referenced in `main.tf.tpl` but not populated in `main.auto.tfvars.tpl`, resulting in an empty tags map being passed to the EKS module. 

### Breaking Changes 💔

None.

### Tests performed 🧪

It will be tested during the execution of the distro's e2e.

### Future work 🔧

None.