### PR TITLE
fix: keep Loki replicas

### DIFF
--- a/templates/distribution/manifests/logging/kapp-configs/logging-operator-crd.yaml
+++ b/templates/distribution/manifests/logging/kapp-configs/logging-operator-crd.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# This file is used to tell kapp to ignore the changes in the conversion strategy
+# of the Logging Operator CRD.
+
+apiVersion: kapp.k14s.io/v1alpha1
+kind: Config
+metadata:
+  name: dummy-logging-operator-crds # needed so kustomize won't complain
+rebaseRules:
+- path: [spec, conversion, strategy]
+  type: copy
+  sources: [existing, new]
+  resourceMatchers:
+    - kindNamespaceNameMatcher:
+        kind: CustomResourceDefinition
+        name: loggings.logging.banzaicloud.io

--- a/templates/distribution/manifests/logging/kapp-configs/loki-hpa.yaml
+++ b/templates/distribution/manifests/logging/kapp-configs/loki-hpa.yaml
@@ -1,0 +1,38 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# This file is used to tell kapp to ignore the changes in the replica fields of 
+# the Loki components that have an HPA configured.
+# This is needed because the HPA will change the replica count based on the load,
+# and we don't want kapp to consider this as a drift from the desired state.
+
+apiVersion: kapp.k14s.io/v1alpha1
+kind: Config
+metadata:
+  name: dummy # needed so kustomize won't complain
+rebaseRules:
+- path: [spec, replicas]
+  type: copy
+  sources: [existing, new]
+  resourceMatchers:
+  - kindNamespaceNameMatcher:
+      kind: Deployment
+      namespace: logging
+      name: loki-distributed-distributor
+  - kindNamespaceNameMatcher:
+      kind: Deployment
+      namespace: logging
+      name: loki-distributed-gateway
+  - kindNamespaceNameMatcher:
+      kind: StatefulSet
+      namespace: logging
+      name: loki-distributed-ingester
+  - kindNamespaceNameMatcher:
+      kind: Deployment
+      namespace: logging
+      name: loki-distributed-querier
+  - kindNamespaceNameMatcher:
+      kind: Deployment
+      namespace: logging
+      name: loki-distributed-query-frontend

--- a/templates/distribution/manifests/logging/kustomization.yaml.tpl
+++ b/templates/distribution/manifests/logging/kustomization.yaml.tpl
@@ -16,6 +16,7 @@ kind: Kustomization
 resources:
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/logging/katalog/logging-operator" }}
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/logging/katalog/logging-operated" }}
+  - kapp-configs/logging-operator-crd.yaml
 {{- if eq $loggingType "loki" "opensearch" }}
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/logging/katalog/minio-ha" }}
   {{- if ne .spec.distribution.modules.ingress.nginx.type "none" }}
@@ -49,6 +50,7 @@ resources:
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/logging/katalog/loki-configs/kubernetes" }}
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/logging/katalog/loki-configs/systemd" }}
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/logging/katalog/loki-distributed" }}
+  - kapp-configs/loki-hpa.yaml
 {{- end }}
 
 {{- if eq .spec.distribution.common.networkPoliciesEnabled true }}


### PR DESCRIPTION
### Summary 💡

Add kapp configuration definitions to avoid overriding the replicas number set by the HPAs we deploy together with Loki.

Fixes #438

### Description 📝

I took the chance and also added an exception to a field of the Logging Operator CRD that was being removed by kapp on every apply. This did not have the impact that changing the replicas for Loki's components has, but I fixed it while I was at it.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested the change with SD version 1.33 (wip), verified that replica number is not overwritten.
- [x] Tested that there are no errors on a clean deploy.

### Future work 🔧

There are other places where we could do the same probably.