### PR TITLE
chore(distribution): ignore conversion strategy for Prometheus Operator CRD

### DIFF
--- a/templates/distribution/manifests/monitoring/kapp-configs/prometheus-operator-crd.yaml
+++ b/templates/distribution/manifests/monitoring/kapp-configs/prometheus-operator-crd.yaml
@@ -1,0 +1,37 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# This file is used to tell kapp to ignore the changes in the conversion strategy
+# of the Prometheus Operator CRDs.
+# Note that this won't be deployed to the cluster.
+
+apiVersion: kapp.k14s.io/v1alpha1
+kind: Config
+metadata:
+  name: dummy-prometheus-operator-crds # needed so kustomize won't complain
+rebaseRules:
+- path: [spec, conversion, strategy]
+  type: copy
+  sources: [existing, new]
+  resourceMatchers:
+    - anyMatcher:
+        matchers:
+        - kindNamespaceNameMatcher:
+            kind: CustomResourceDefinition
+            name: alertmanagerconfigs.monitoring.coreos.com
+        - kindNamespaceNameMatcher:
+            kind: CustomResourceDefinition
+            name: alertmanagers.monitoring.coreos.com
+        - kindNamespaceNameMatcher:
+            kind: CustomResourceDefinition
+            name: prometheusagents.monitoring.coreos.com
+        - kindNamespaceNameMatcher:
+            kind: CustomResourceDefinition
+            name: prometheuses.monitoring.coreos.com
+        - kindNamespaceNameMatcher:
+            kind: CustomResourceDefinition
+            name: scrapeconfigs.monitoring.coreos.com
+        - kindNamespaceNameMatcher:
+            kind: CustomResourceDefinition
+            name: thanosrulers.monitoring.coreos.com

--- a/templates/distribution/manifests/monitoring/kustomization.yaml.tpl
+++ b/templates/distribution/manifests/monitoring/kustomization.yaml.tpl
@@ -12,6 +12,7 @@ kind: Kustomization
 
 resources:
 {{- /* common components for all the monitoring types */}}
+  - kapp-configs/prometheus-operator-crd.yaml
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/monitoring/katalog/prometheus-operator" }}
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/monitoring/katalog/kube-proxy-metrics" }}
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/monitoring/katalog/kube-state-metrics" }}


### PR DESCRIPTION
### Summary 💡

Ignore the conversion strategy in all Prometheus Operator CRDs, so kapp won't try to remove it from the depoyed versions on each apply for it to be automatically added back by the API server right after.

Relates:
- #439


### Description 📝

This PR takes the approach done on #439 to the Prometheus CRDs, so they don't get changed on every apply, adding noice to the diff in the logs and making a change that will be reverted back anyway right after.

Before:

```
Changes

Namespace  Name                                       Kind                      Age  Op      Op st.               Wait to    Rs  Ri
(cluster)  alertmanagerconfigs.monitoring.coreos.com  CustomResourceDefinition  3m   update  fallback on replace  reconcile  ok  -
^          alertmanagers.monitoring.coreos.com        CustomResourceDefinition  3m   update  fallback on replace  reconcile  ok  -
^          prometheusagents.monitoring.coreos.com     CustomResourceDefinition  3m   update  fallback on replace  reconcile  ok  -
^          prometheuses.monitoring.coreos.com         CustomResourceDefinition  3m   update  fallback on replace  reconcile  ok  -
^          scrapeconfigs.monitoring.coreos.com        CustomResourceDefinition  3m   update  fallback on replace  reconcile  ok  -
^          thanosrulers.monitoring.coreos.com         CustomResourceDefinition  3m   update  fallback on replace  reconcile  ok  -

Op:      0 create, 0 delete, 6 update, 0 noop, 0 exists
Wait to: 6 reconcile, 0 delete, 0 noop
```

After:

```
Changes

Namespace  Name  Kind  Age  Op  Op st.  Wait to  Rs  Ri

Op:      0 create, 0 delete, 0 update, 0 noop, 0 exists
Wait to: 0 reconcile, 0 delete, 0 noop
```

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested that the field does not show up anymore in the diff.

### Future work 🔧

None