### PR TITLE
fix(templates/monitoring): make kustomization.yaml v5 compatible

### DIFF
--- a/templates/distribution/manifests/monitoring/kustomization.yaml.tpl
+++ b/templates/distribution/manifests/monitoring/kustomization.yaml.tpl
@@ -60,68 +60,68 @@ resources:
   - policies
 {{- end }}
 
-patchesStrategicMerge:
-  - patches/infra-nodes.yml
+patches:
+  - path: patches/infra-nodes.yml
 {{- if eq .spec.distribution.common.provider.type "eks" }}{{/* in EKS there are no files to monitor on nodes */}}
-  - |-
-    $patch: delete
-    apiVersion: apps/v1
-    kind: DaemonSet
-    metadata:
-      namespace: monitoring
-      name: x509-certificate-exporter-data-plane
+  - patch: |-
+      $patch: delete
+      apiVersion: apps/v1
+      kind: DaemonSet
+      metadata:
+        namespace: monitoring
+        name: x509-certificate-exporter-data-plane
 {{- end }}
 {{- if or (eq $monitoringType "prometheus") (eq $monitoringType "mimir") }}
-  - patches/alertmanager-operated.yml
+  - path: patches/alertmanager-operated.yml
   {{- if .checks.storageClassAvailable }}
   {{- /* notice that prometheus-operated is (also) installed as a dependency of mimir in its kustomize base */}}
-  - patches/prometheus-operated.yml
+  - path: patches/prometheus-operated.yml
     {{- if and (eq $monitoringType "mimir") (eq .spec.distribution.modules.monitoring.mimir.backend "minio") }}
-  - patches/minio.yml
+  - path: patches/minio.yml
     {{- end }}
   {{- end }}
 {{- end }}
 {{- if not .spec.distribution.modules.monitoring.alertmanager.installDefaultRules }}
 {{- if .spec.distribution.modules.monitoring.alertmanager.deadManSwitchWebhookUrl }}
-  - |-
-    $patch: delete
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      namespace: monitoring
-      name: healthchecks-webhook
+  - patch: |-
+      $patch: delete
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        namespace: monitoring
+        name: healthchecks-webhook
 {{- end }}
 {{- if .spec.distribution.modules.monitoring.alertmanager.slackWebhookUrl }}
-  - |-
-    $patch: delete
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      namespace: monitoring
-      name: infra-slack-webhook
-  - |-
-    $patch: delete
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      namespace: monitoring
-      name: k8s-slack-webhook
+  - patch: |-
+      $patch: delete
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        namespace: monitoring
+        name: infra-slack-webhook
+  - patch: |-
+      $patch: delete
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        namespace: monitoring
+        name: k8s-slack-webhook
 {{- end }}
 {{- end }}
 {{- if or (eq $monitoringType "prometheus") (eq $monitoringType "mimir") }}
   {{- if not $installEnhancedHPAMetrics }}
-  - |-
-    $patch: delete
-    apiVersion: apiregistration.k8s.io/v1
-    kind: APIService
-    metadata:
-      name: v1beta1.custom.metrics.k8s.io
-  - |-
-    $patch: delete
-    apiVersion: apiregistration.k8s.io/v1
-    kind: APIService
-    metadata:
-      name: v1beta1.external.metrics.k8s.io
+  - patch: |-
+      $patch: delete
+      apiVersion: apiregistration.k8s.io/v1
+      kind: APIService
+      metadata:
+        name: v1beta1.custom.metrics.k8s.io
+  - patch: |-
+      $patch: delete
+      apiVersion: apiregistration.k8s.io/v1
+      kind: APIService
+      metadata:
+        name: v1beta1.external.metrics.k8s.io
   {{- end }}
 {{- end }}
 


### PR DESCRIPTION
### Summary 💡

Update kustomization.yaml template file for the monitoring module to use Kustomize v5 syntax and drop deprecated features usage like PatchesStrategicMerge.

### Description 📝

See summary

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested that the apply with the monitoring module enable is still working.
- [x] Tested changing some options like `installEnhancedHPAMetrics` and `installDefaultRules` and verified that the patches are correctly applied.
-->

### Future work 🔧

None
