### PR TITLE
feat(schemas/on-prem): add containerd TOML settings

### DIFF
--- a/docs/schemas/kfddistribution-kfd-v1alpha2.md
+++ b/docs/schemas/kfddistribution-kfd-v1alpha2.md
@@ -3695,7 +3695,7 @@ The value of the toleration
 
 ### Description
 
-BlockSize specifies the CIDR prefex length to use when allocating per-node IP blocks from the main IP pool CIDR. WARNING: The value for this field cannot be changed once set. Default is 26.
+BlockSize specifies the CIDR prefix length to use when allocating per-node IP blocks from the main IP pool CIDR. WARNING: The value for this field cannot be changed once set. Default is 26.
 
 ## .spec.distribution.modules.networking.tigeraOperator.overrides
 
@@ -3766,7 +3766,13 @@ The value of the toleration
 
 ### Description
 
-Allows specifing a CIDR for the Pods network different from `.spec.kubernetes.podCidr`. If not set the default is to use `.spec.kubernetes.podCidr`. WARNING: The value for this field cannot be changed once set.
+Specifies a custom CIDR for the default Pods IPPool.
+If unset, the Tigera Operator will try to detect it from the cluster:
+- OpenShift -> OpenShift Network config
+- kubeadm -> kubeadm-config ConfigMap
+- EKS -> defaults to 172.16.0.0/16 (VXLAN)
+- otherwise -> defaults to 192.168.0.0/16.
+WARNING: this field cannot be changed once set.
 
 ### Constraints
 

--- a/docs/schemas/onpremises-kfd-v1alpha2.md
+++ b/docs/schemas/onpremises-kfd-v1alpha2.md
@@ -5091,14 +5091,42 @@ Sets the cloud provider for the Kubelet
 
 ### Properties
 
-| Property                                                                  | Type      | Required |
-|:--------------------------------------------------------------------------|:----------|:---------|
-| [manageRepositories](#speckubernetesadvancedcontainerdmanagerepositories) | `boolean` | Optional |
-| [registryConfigs](#speckubernetesadvancedcontainerdregistryconfigs)       | `array`   | Optional |
+| Property                                                                            | Type      | Required |
+|:------------------------------------------------------------------------------------|:----------|:---------|
+| [debugLevel](#speckubernetesadvancedcontainerddebuglevel)                           | `string`  | Optional |
+| [grpcMaxRecvMessageSize](#speckubernetesadvancedcontainerdgrpcmaxrecvmessagesize)   | `integer` | Optional |
+| [grpcMaxSendMessageSize](#speckubernetesadvancedcontainerdgrpcmaxsendmessagesize)   | `integer` | Optional |
+| [manageRepositories](#speckubernetesadvancedcontainerdmanagerepositories)           | `boolean` | Optional |
+| [maxContainerLogLineSize](#speckubernetesadvancedcontainerdmaxcontainerloglinesize) | `integer` | Optional |
+| [metricsAddress](#speckubernetesadvancedcontainerdmetricsaddress)                   | `string`  | Optional |
+| [metricsGrpcHistogram](#speckubernetesadvancedcontainerdmetricsgrpchistogram)       | `boolean` | Optional |
+| [oomScore](#speckubernetesadvancedcontainerdoomscore)                               | `integer` | Optional |
+| [registryConfigs](#speckubernetesadvancedcontainerdregistryconfigs)                 | `array`   | Optional |
+| [stateDir](#speckubernetesadvancedcontainerdstatedir)                               | `string`  | Optional |
+| [storageDir](#speckubernetesadvancedcontainerdstoragedir)                           | `string`  | Optional |
+| [systemdDir](#speckubernetesadvancedcontainerdsystemddir)                           | `string`  | Optional |
 
 ### Description
 
 Advanced configuration for containerd
+
+## .spec.kubernetes.advanced.containerd.debugLevel
+
+### Description
+
+The Containerd debug level used in the config.toml file.
+
+## .spec.kubernetes.advanced.containerd.grpcMaxRecvMessageSize
+
+### Description
+
+The Containerd gRPC maximum receive message size in bytes used in the config.toml file.
+
+## .spec.kubernetes.advanced.containerd.grpcMaxSendMessageSize
+
+### Description
+
+The Containerd gRPC maximum send message size in bytes used in the config.toml file.
 
 ## .spec.kubernetes.advanced.containerd.manageRepositories
 
@@ -5106,6 +5134,30 @@ Advanced configuration for containerd
 
 Set to false if you manage the NVIDIA container toolkit's repositories externally and wish to skip their configuration with furyctl. Default is true.
 Notice that containerd itself is installed from binaries and does not use a repository. See `.spec.kubernetes.advanced.airGap` for other download options for containerd.
+
+## .spec.kubernetes.advanced.containerd.maxContainerLogLineSize
+
+### Description
+
+The maximum container log line size in bytes used in the config.toml file.
+
+## .spec.kubernetes.advanced.containerd.metricsAddress
+
+### Description
+
+The Containerd metrics address used in the config.toml file.
+
+## .spec.kubernetes.advanced.containerd.metricsGrpcHistogram
+
+### Description
+
+Enable Containerd metrics gRPC histogram in the config.toml file.
+
+## .spec.kubernetes.advanced.containerd.oomScore
+
+### Description
+
+The Containerd OOM score adjustment used in the config.toml file.
 
 ## .spec.kubernetes.advanced.containerd.registryConfigs
 
@@ -5153,6 +5205,24 @@ Registry address on which you would like to configure authentication or mirror(s
 ### Description
 
 The username containerd will use to authenticate against the registry.
+
+## .spec.kubernetes.advanced.containerd.stateDir
+
+### Description
+
+The Containerd state directory used in the config.toml file.
+
+## .spec.kubernetes.advanced.containerd.storageDir
+
+### Description
+
+The Containerd storage directory used in the config.toml file.
+
+## .spec.kubernetes.advanced.containerd.systemdDir
+
+### Description
+
+The Containerd systemd service directory used in the config.toml file.
 
 ## .spec.kubernetes.advanced.encryption
 

--- a/docs/schemas/onpremises-kfd-v1alpha2.md
+++ b/docs/schemas/onpremises-kfd-v1alpha2.md
@@ -5091,20 +5091,21 @@ Sets the cloud provider for the Kubelet
 
 ### Properties
 
-| Property                                                                            | Type      | Required |
-|:------------------------------------------------------------------------------------|:----------|:---------|
-| [debugLevel](#speckubernetesadvancedcontainerddebuglevel)                           | `string`  | Optional |
-| [grpcMaxRecvMessageSize](#speckubernetesadvancedcontainerdgrpcmaxrecvmessagesize)   | `integer` | Optional |
-| [grpcMaxSendMessageSize](#speckubernetesadvancedcontainerdgrpcmaxsendmessagesize)   | `integer` | Optional |
-| [manageRepositories](#speckubernetesadvancedcontainerdmanagerepositories)           | `boolean` | Optional |
-| [maxContainerLogLineSize](#speckubernetesadvancedcontainerdmaxcontainerloglinesize) | `integer` | Optional |
-| [metricsAddress](#speckubernetesadvancedcontainerdmetricsaddress)                   | `string`  | Optional |
-| [metricsGrpcHistogram](#speckubernetesadvancedcontainerdmetricsgrpchistogram)       | `boolean` | Optional |
-| [oomScore](#speckubernetesadvancedcontainerdoomscore)                               | `integer` | Optional |
-| [registryConfigs](#speckubernetesadvancedcontainerdregistryconfigs)                 | `array`   | Optional |
-| [stateDir](#speckubernetesadvancedcontainerdstatedir)                               | `string`  | Optional |
-| [storageDir](#speckubernetesadvancedcontainerdstoragedir)                           | `string`  | Optional |
-| [systemdDir](#speckubernetesadvancedcontainerdsystemddir)                           | `string`  | Optional |
+| Property                                                                                                  | Type      | Required |
+|:----------------------------------------------------------------------------------------------------------|:----------|:---------|
+| [debugLevel](#speckubernetesadvancedcontainerddebuglevel)                                                 | `string`  | Optional |
+| [deviceOwnershipFromSecurityContext](#speckubernetesadvancedcontainerddeviceownershipfromsecuritycontext) | `boolean` | Optional |
+| [grpcMaxRecvMessageSize](#speckubernetesadvancedcontainerdgrpcmaxrecvmessagesize)                         | `integer` | Optional |
+| [grpcMaxSendMessageSize](#speckubernetesadvancedcontainerdgrpcmaxsendmessagesize)                         | `integer` | Optional |
+| [manageRepositories](#speckubernetesadvancedcontainerdmanagerepositories)                                 | `boolean` | Optional |
+| [maxContainerLogLineSize](#speckubernetesadvancedcontainerdmaxcontainerloglinesize)                       | `integer` | Optional |
+| [metricsAddress](#speckubernetesadvancedcontainerdmetricsaddress)                                         | `string`  | Optional |
+| [metricsGrpcHistogram](#speckubernetesadvancedcontainerdmetricsgrpchistogram)                             | `boolean` | Optional |
+| [oomScore](#speckubernetesadvancedcontainerdoomscore)                                                     | `integer` | Optional |
+| [registryConfigs](#speckubernetesadvancedcontainerdregistryconfigs)                                       | `array`   | Optional |
+| [stateDir](#speckubernetesadvancedcontainerdstatedir)                                                     | `string`  | Optional |
+| [storageDir](#speckubernetesadvancedcontainerdstoragedir)                                                 | `string`  | Optional |
+| [systemdDir](#speckubernetesadvancedcontainerdsystemddir)                                                 | `string`  | Optional |
 
 ### Description
 
@@ -5115,6 +5116,12 @@ Advanced configuration for containerd
 ### Description
 
 The Containerd debug level used in the config.toml file.
+
+## .spec.kubernetes.advanced.containerd.deviceOwnershipFromSecurityContext
+
+### Description
+
+Set to apply device ownership from the container runtime's security context instead of the host's defaults, used in the config.toml file.
 
 ## .spec.kubernetes.advanced.containerd.grpcMaxRecvMessageSize
 

--- a/pkg/apis/kfddistribution/v1alpha2/public/schema.go
+++ b/pkg/apis/kfddistribution/v1alpha2/public/schema.go
@@ -2005,7 +2005,7 @@ func (j *SpecDistributionModulesNetworkingCilium) UnmarshalJSON(b []byte) error 
 }
 
 type SpecDistributionModulesNetworkingTigeraOperator struct {
-	// BlockSize specifies the CIDR prefex length to use when allocating per-node IP
+	// BlockSize specifies the CIDR prefix length to use when allocating per-node IP
 	// blocks from the main IP pool CIDR. WARNING: The value for this field cannot be
 	// changed once set. Default is 26.
 	BlockSize *int `json:"blockSize,omitempty" yaml:"blockSize,omitempty" mapstructure:"blockSize,omitempty"`
@@ -2013,10 +2013,13 @@ type SpecDistributionModulesNetworkingTigeraOperator struct {
 	// Overrides corresponds to the JSON schema field "overrides".
 	Overrides *TypesFuryModuleComponentOverrides `json:"overrides,omitempty" yaml:"overrides,omitempty" mapstructure:"overrides,omitempty"`
 
-	// Allows specifing a CIDR for the Pods network different from
-	// `.spec.kubernetes.podCidr`. If not set the default is to use
-	// `.spec.kubernetes.podCidr`. WARNING: The value for this field cannot be changed
-	// once set.
+	// Specifies a custom CIDR for the default Pods IPPool.
+	// If unset, the Tigera Operator will try to detect it from the cluster:
+	// - OpenShift -> OpenShift Network config
+	// - kubeadm -> kubeadm-config ConfigMap
+	// - EKS -> defaults to 172.16.0.0/16 (VXLAN)
+	// - otherwise -> defaults to 192.168.0.0/16.
+	// WARNING: this field cannot be changed once set.
 	PodCidr *TypesCidr `json:"podCidr,omitempty" yaml:"podCidr,omitempty" mapstructure:"podCidr,omitempty"`
 }
 

--- a/pkg/apis/onpremises/v1alpha2/public/schema.go
+++ b/pkg/apis/onpremises/v1alpha2/public/schema.go
@@ -1823,6 +1823,10 @@ type SpecKubernetesAdvancedContainerd struct {
 	// The Containerd debug level used in the config.toml file.
 	DebugLevel *string `json:"debugLevel,omitempty" yaml:"debugLevel,omitempty" mapstructure:"debugLevel,omitempty"`
 
+	// Set to apply device ownership from the container runtime's security context
+	// instead of the host's defaults, used in the config.toml file.
+	DeviceOwnershipFromSecurityContext *bool `json:"deviceOwnershipFromSecurityContext,omitempty" yaml:"deviceOwnershipFromSecurityContext,omitempty" mapstructure:"deviceOwnershipFromSecurityContext,omitempty"`
+
 	// The Containerd gRPC maximum receive message size in bytes used in the
 	// config.toml file.
 	GrpcMaxRecvMessageSize *int `json:"grpcMaxRecvMessageSize,omitempty" yaml:"grpcMaxRecvMessageSize,omitempty" mapstructure:"grpcMaxRecvMessageSize,omitempty"`

--- a/pkg/apis/onpremises/v1alpha2/public/schema.go
+++ b/pkg/apis/onpremises/v1alpha2/public/schema.go
@@ -1820,6 +1820,17 @@ type SpecKubernetesAdvancedCloud struct {
 
 // Advanced configuration for containerd
 type SpecKubernetesAdvancedContainerd struct {
+	// The Containerd debug level used in the config.toml file.
+	DebugLevel *string `json:"debugLevel,omitempty" yaml:"debugLevel,omitempty" mapstructure:"debugLevel,omitempty"`
+
+	// The Containerd gRPC maximum receive message size in bytes used in the
+	// config.toml file.
+	GrpcMaxRecvMessageSize *int `json:"grpcMaxRecvMessageSize,omitempty" yaml:"grpcMaxRecvMessageSize,omitempty" mapstructure:"grpcMaxRecvMessageSize,omitempty"`
+
+	// The Containerd gRPC maximum send message size in bytes used in the config.toml
+	// file.
+	GrpcMaxSendMessageSize *int `json:"grpcMaxSendMessageSize,omitempty" yaml:"grpcMaxSendMessageSize,omitempty" mapstructure:"grpcMaxSendMessageSize,omitempty"`
+
 	// Set to false if you manage the NVIDIA container toolkit's repositories
 	// externally and wish to skip their configuration with furyctl. Default is true.
 	// Notice that containerd itself is installed from binaries and does not use a
@@ -1827,8 +1838,29 @@ type SpecKubernetesAdvancedContainerd struct {
 	// for containerd.
 	ManageRepositories *bool `json:"manageRepositories,omitempty" yaml:"manageRepositories,omitempty" mapstructure:"manageRepositories,omitempty"`
 
+	// The maximum container log line size in bytes used in the config.toml file.
+	MaxContainerLogLineSize *int `json:"maxContainerLogLineSize,omitempty" yaml:"maxContainerLogLineSize,omitempty" mapstructure:"maxContainerLogLineSize,omitempty"`
+
+	// The Containerd metrics address used in the config.toml file.
+	MetricsAddress *string `json:"metricsAddress,omitempty" yaml:"metricsAddress,omitempty" mapstructure:"metricsAddress,omitempty"`
+
+	// Enable Containerd metrics gRPC histogram in the config.toml file.
+	MetricsGrpcHistogram *bool `json:"metricsGrpcHistogram,omitempty" yaml:"metricsGrpcHistogram,omitempty" mapstructure:"metricsGrpcHistogram,omitempty"`
+
+	// The Containerd OOM score adjustment used in the config.toml file.
+	OomScore *int `json:"oomScore,omitempty" yaml:"oomScore,omitempty" mapstructure:"oomScore,omitempty"`
+
 	// RegistryConfigs corresponds to the JSON schema field "registryConfigs".
 	RegistryConfigs SpecKubernetesAdvancedContainerdRegistryConfigs `json:"registryConfigs,omitempty" yaml:"registryConfigs,omitempty" mapstructure:"registryConfigs,omitempty"`
+
+	// The Containerd state directory used in the config.toml file.
+	StateDir *string `json:"stateDir,omitempty" yaml:"stateDir,omitempty" mapstructure:"stateDir,omitempty"`
+
+	// The Containerd storage directory used in the config.toml file.
+	StorageDir *string `json:"storageDir,omitempty" yaml:"storageDir,omitempty" mapstructure:"storageDir,omitempty"`
+
+	// The Containerd systemd service directory used in the config.toml file.
+	SystemdDir *string `json:"systemdDir,omitempty" yaml:"systemdDir,omitempty" mapstructure:"systemdDir,omitempty"`
 }
 
 // Allows specifying custom configuration for a registry at containerd level. You

--- a/schemas/public/onpremises-kfd-v1alpha2.json
+++ b/schemas/public/onpremises-kfd-v1alpha2.json
@@ -638,6 +638,10 @@
         "maxContainerLogLineSize": {
           "type": "integer",
           "description": "The maximum container log line size in bytes used in the config.toml file."
+        },
+        "deviceOwnershipFromSecurityContext": {
+          "type": "boolean",
+          "description": "Set to true to apply device ownership from the container runtime's security context instead of the host's defaults, used in the config.toml file."
         }
       }
     },

--- a/schemas/public/onpremises-kfd-v1alpha2.json
+++ b/schemas/public/onpremises-kfd-v1alpha2.json
@@ -598,6 +598,46 @@
         "manageRepositories": {
           "type": "boolean",
           "description": "Set to false if you manage the NVIDIA container toolkit's repositories externally and wish to skip their configuration with furyctl. Default is true.\nNotice that containerd itself is installed from binaries and does not use a repository. See `.spec.kubernetes.advanced.airGap` for other download options for containerd."
+        },
+        "storageDir": {
+          "type": "string",
+          "description": "The Containerd storage directory used in the config.toml file."
+        },
+        "stateDir": {
+          "type": "string",
+          "description": "The Containerd state directory used in the config.toml file."
+        },
+        "systemdDir": {
+          "type": "string",
+          "description": "The Containerd systemd service directory used in the config.toml file."
+        },
+        "oomScore": {
+          "type": "integer",
+          "description": "The Containerd OOM score adjustment used in the config.toml file."
+        },
+        "grpcMaxRecvMessageSize": {
+          "type": "integer",
+          "description": "The Containerd gRPC maximum receive message size in bytes used in the config.toml file."
+        },
+        "grpcMaxSendMessageSize": {
+          "type": "integer",
+          "description": "The Containerd gRPC maximum send message size in bytes used in the config.toml file."
+        },
+        "debugLevel": {
+          "type": "string",
+          "description": "The Containerd debug level used in the config.toml file."
+        },
+        "metricsAddress": {
+          "type": "string",
+          "description": "The Containerd metrics address used in the config.toml file."
+        },
+        "metricsGrpcHistogram": {
+          "type": "boolean",
+          "description": "Enable Containerd metrics gRPC histogram in the config.toml file."
+        },
+        "maxContainerLogLineSize": {
+          "type": "integer",
+          "description": "The maximum container log line size in bytes used in the config.toml file."
         }
       }
     },

--- a/templates/kubernetes/onpremises/hosts.yaml.tpl
+++ b/templates/kubernetes/onpremises/hosts.yaml.tpl
@@ -285,6 +285,9 @@ all:
     {{- if hasKeyAny .spec.kubernetes.advanced.containerd "maxContainerLogLineSize" }}
     containerd_max_container_log_line_size: {{ .spec.kubernetes.advanced.containerd.maxContainerLogLineSize }}
     {{- end }}
+    {{- if hasKeyAny .spec.kubernetes.advanced.containerd "deviceOwnershipFromSecurityContext" }}
+    containerd_device_ownership_from_security_context: {{ .spec.kubernetes.advanced.containerd.deviceOwnershipFromSecurityContext }}
+    {{- end }}
     {{- end }}
     {{- if (index .spec.kubernetes.advanced "encryption") }}
     {{- if (index .spec.kubernetes.advanced.encryption "tlsCipherSuites") }}

--- a/templates/kubernetes/onpremises/hosts.yaml.tpl
+++ b/templates/kubernetes/onpremises/hosts.yaml.tpl
@@ -255,6 +255,36 @@ all:
     {{- if hasKeyAny .spec.kubernetes.advanced.containerd "manageRepositories" }}
     containerd_manage_repositories: {{ .spec.kubernetes.advanced.containerd.manageRepositories }}
     {{- end }}
+    {{- if hasKeyAny .spec.kubernetes.advanced.containerd "storageDir" }}
+    containerd_storage_dir: "{{ .spec.kubernetes.advanced.containerd.storageDir }}"
+    {{- end }}
+    {{- if hasKeyAny .spec.kubernetes.advanced.containerd "stateDir" }}
+    containerd_state_dir: "{{ .spec.kubernetes.advanced.containerd.stateDir }}"
+    {{- end }}
+    {{- if hasKeyAny .spec.kubernetes.advanced.containerd "systemdDir" }}
+    containerd_systemd_dir: "{{ .spec.kubernetes.advanced.containerd.systemdDir }}"
+    {{- end }}
+    {{- if hasKeyAny .spec.kubernetes.advanced.containerd "oomScore" }}
+    containerd_oom_score: {{ .spec.kubernetes.advanced.containerd.oomScore }}
+    {{- end }}
+    {{- if hasKeyAny .spec.kubernetes.advanced.containerd "grpcMaxRecvMessageSize" }}
+    containerd_grpc_max_recv_message_size: {{ .spec.kubernetes.advanced.containerd.grpcMaxRecvMessageSize }}
+    {{- end }}
+    {{- if hasKeyAny .spec.kubernetes.advanced.containerd "grpcMaxSendMessageSize" }}
+    containerd_grpc_max_send_message_size: {{ .spec.kubernetes.advanced.containerd.grpcMaxSendMessageSize }}
+    {{- end }}
+    {{- if hasKeyAny .spec.kubernetes.advanced.containerd "debugLevel" }}
+    containerd_debug_level: "{{ .spec.kubernetes.advanced.containerd.debugLevel }}"
+    {{- end }}
+    {{- if hasKeyAny .spec.kubernetes.advanced.containerd "metricsAddress" }}
+    containerd_metrics_address: "{{ .spec.kubernetes.advanced.containerd.metricsAddress }}"
+    {{- end }}
+    {{- if hasKeyAny .spec.kubernetes.advanced.containerd "metricsGrpcHistogram" }}
+    containerd_metrics_grpc_histogram: {{ .spec.kubernetes.advanced.containerd.metricsGrpcHistogram }}
+    {{- end }}
+    {{- if hasKeyAny .spec.kubernetes.advanced.containerd "maxContainerLogLineSize" }}
+    containerd_max_container_log_line_size: {{ .spec.kubernetes.advanced.containerd.maxContainerLogLineSize }}
+    {{- end }}
     {{- end }}
     {{- if (index .spec.kubernetes.advanced "encryption") }}
     {{- if (index .spec.kubernetes.advanced.encryption "tlsCipherSuites") }}


### PR DESCRIPTION
### Summary 💡

Add containerd TOML settings configuration for on-premises provider to allow customization of containerd runtime parameters.

Relates:

### Description 📝

Exposes containerd configuration fields, already present on the on-premises installer, for environments requiring custom container runtime settings. All fields map to containerd config.toml parameters.

Schema additions:
- `spec.kubernetes.advanced.containerd.storageDir`: Containerd storage directory
- `spec.kubernetes.advanced.containerd.stateDir`: Containerd state directory
- `spec.kubernetes.advanced.containerd.systemdDir`: Containerd systemd service directory
- `spec.kubernetes.advanced.containerd.oomScore`: Containerd OOM score adjustment
- `spec.kubernetes.advanced.containerd.grpcMaxRecvMessageSize`: Containerd gRPC max receive message size in bytes
- `spec.kubernetes.advanced.containerd.grpcMaxSendMessageSize`: Containerd gRPC max send message size in bytes
- `spec.kubernetes.advanced.containerd.debugLevel`: Containerd debug level
- `spec.kubernetes.advanced.containerd.metricsAddress`: Containerd metrics address
- `spec.kubernetes.advanced.containerd.metricsGrpcHistogram`: Enable Containerd metrics gRPC histogram
- `spec.kubernetes.advanced.containerd.maxContainerLogLineSize`: Max container log line size in bytes
- `spec.kubernetes.advanced.containerd.deviceOwnershipFromSecurityContext`: To apply device ownership from the container runtime's security context instead of the host's defaults

All fields are optional. When omitted, defaults to existing containerd configuration.

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] Checked backward compatibility with existing fields.
- [x] Tested template rendering with containerd settings.

### Future work 🔧

None.