### PR TITLE
refactor: refactor repository management variables

### DIFF
--- a/docs/releases/v1.33.0.md
+++ b/docs/releases/v1.33.0.md
@@ -225,21 +225,22 @@ degraded performance and availability:
 
 - [[#435](https://github.com/sighupio/distribution/pull/435)] Repository management lifecycle configuration for OnPremises provider:
   - Added new boolean configuration fields for environments where package repositories are configured outside of furyctl.
-    - `spec.kubernetes.loadBalancers.manageRepositories`: Controls HAProxy repository setup
-    - `spec.kubernetes.advanced.containerd.manageRepositories`: Controls NVIDIA container toolkit's repository setup
-    - `spec.kubernetes.advanced.manageRepositories`: Controls Kubernetes package repository setup
-  - All fields are optional. If omitted, the system defaults to automatic repository management.
+    - `spec.kubernetes.loadBalancers.selfmanagedRepositories`: Controls HAProxy repository setup
+    - `spec.kubernetes.advanced.containerd.selfmanagedRepositories`: Controls NVIDIA container toolkit's repository setup
+    - `spec.kubernetes.advanced.selfmanagedRepositories`: Controls Kubernetes package repository setup
+  - All fields are optional. If omitted, the system defaults to automatic repository management (`selfmanagedRepositories: false`).
+  - To handle repositories manually and disable automatic repository management, set `selfmanagedRepositories: true`:
 
     ```yaml
     spec:
       kubernetes:
         loadBalancers:
           enabled: true
-          manageRepositories: false
+          selfmanagedRepositories: true  # Handle HAProxy repositories manually
         advanced:
-          manageRepositories: false
+          selfmanagedRepositories: true  # Handle Kubernetes repositories manually
           containerd:
-            manageRepositories: false
+            selfmanagedRepositories: true  # Handle NVIDIA container toolkit repositories manually
     ```
 
 - [[#353](https://github.com/sighupio/fury-distribution/pull/353)] **Add EKS self-managed node pool default override options for IDMS**: add a variable to override the default properies for EKS self-managed node pools. Currently support only the IDMS ones.

--- a/docs/schemas/ekscluster-kfd-v1alpha2.md
+++ b/docs/schemas/ekscluster-kfd-v1alpha2.md
@@ -5869,7 +5869,7 @@ The type of Node Pool, can be `self-managed` for using customization like custom
 
 ### Description
 
-Additional properties in common for all self-managed node pools. Currently only IMDS properties are supported.
+Default properties to set for all self-managed and eks-managed node pools. Currently only IMDS properties are supported.
 
 ## .spec.kubernetes.nodePoolsCommon.metadataHttpEndpoint
 

--- a/docs/schemas/onpremises-kfd-v1alpha2.md
+++ b/docs/schemas/onpremises-kfd-v1alpha2.md
@@ -4920,21 +4920,21 @@ Defines the Kubernetes components configuration and the values needed for the ku
 
 ### Properties
 
-| Property                                                            | Type      | Required |
-|:--------------------------------------------------------------------|:----------|:---------|
-| [airGap](#speckubernetesadvancedairgap)                             | `object`  | Optional |
-| [apiServerCertSANs](#speckubernetesadvancedapiservercertsans)       | `array`   | Optional |
-| [cloud](#speckubernetesadvancedcloud)                               | `object`  | Optional |
-| [containerd](#speckubernetesadvancedcontainerd)                     | `object`  | Optional |
-| [controllerManager](#speckubernetesadvancedcontrollermanager)       | `object`  | Optional |
-| [encryption](#speckubernetesadvancedencryption)                     | `object`  | Optional |
-| [eventRateLimits](#speckubernetesadvancedeventratelimits)           | `array`   | Optional |
-| [kernelParameters](#speckubernetesadvancedkernelparameters)         | `array`   | Optional |
-| [kubeletConfiguration](#speckubernetesadvancedkubeletconfiguration) | `object`  | Optional |
-| [manageRepositories](#speckubernetesadvancedmanagerepositories)     | `boolean` | Optional |
-| [oidc](#speckubernetesadvancedoidc)                                 | `object`  | Optional |
-| [registry](#speckubernetesadvancedregistry)                         | `string`  | Optional |
-| [users](#speckubernetesadvancedusers)                               | `object`  | Optional |
+| Property                                                                  | Type      | Required |
+|:--------------------------------------------------------------------------|:----------|:---------|
+| [airGap](#speckubernetesadvancedairgap)                                   | `object`  | Optional |
+| [apiServerCertSANs](#speckubernetesadvancedapiservercertsans)             | `array`   | Optional |
+| [cloud](#speckubernetesadvancedcloud)                                     | `object`  | Optional |
+| [containerd](#speckubernetesadvancedcontainerd)                           | `object`  | Optional |
+| [controllerManager](#speckubernetesadvancedcontrollermanager)             | `object`  | Optional |
+| [encryption](#speckubernetesadvancedencryption)                           | `object`  | Optional |
+| [eventRateLimits](#speckubernetesadvancedeventratelimits)                 | `array`   | Optional |
+| [kernelParameters](#speckubernetesadvancedkernelparameters)               | `array`   | Optional |
+| [kubeletConfiguration](#speckubernetesadvancedkubeletconfiguration)       | `object`  | Optional |
+| [oidc](#speckubernetesadvancedoidc)                                       | `object`  | Optional |
+| [registry](#speckubernetesadvancedregistry)                               | `string`  | Optional |
+| [selfmanagedRepositories](#speckubernetesadvancedselfmanagedrepositories) | `boolean` | Optional |
+| [users](#speckubernetesadvancedusers)                                     | `object`  | Optional |
 
 ## .spec.kubernetes.advanced.airGap
 
@@ -5099,12 +5099,12 @@ Sets the cloud provider for the Kubelet
 | [deviceOwnershipFromSecurityContext](#speckubernetesadvancedcontainerddeviceownershipfromsecuritycontext) | `boolean` | Optional |
 | [grpcMaxRecvMessageSize](#speckubernetesadvancedcontainerdgrpcmaxrecvmessagesize)                         | `integer` | Optional |
 | [grpcMaxSendMessageSize](#speckubernetesadvancedcontainerdgrpcmaxsendmessagesize)                         | `integer` | Optional |
-| [manageRepositories](#speckubernetesadvancedcontainerdmanagerepositories)                                 | `boolean` | Optional |
 | [maxContainerLogLineSize](#speckubernetesadvancedcontainerdmaxcontainerloglinesize)                       | `integer` | Optional |
 | [metricsAddress](#speckubernetesadvancedcontainerdmetricsaddress)                                         | `string`  | Optional |
 | [metricsGrpcHistogram](#speckubernetesadvancedcontainerdmetricsgrpchistogram)                             | `boolean` | Optional |
 | [oomScore](#speckubernetesadvancedcontainerdoomscore)                                                     | `integer` | Optional |
 | [registryConfigs](#speckubernetesadvancedcontainerdregistryconfigs)                                       | `array`   | Optional |
+| [selfmanagedRepositories](#speckubernetesadvancedcontainerdselfmanagedrepositories)                       | `boolean` | Optional |
 | [stateDir](#speckubernetesadvancedcontainerdstatedir)                                                     | `string`  | Optional |
 | [storageDir](#speckubernetesadvancedcontainerdstoragedir)                                                 | `string`  | Optional |
 | [systemdDir](#speckubernetesadvancedcontainerdsystemddir)                                                 | `string`  | Optional |
@@ -5136,13 +5136,6 @@ The Containerd gRPC maximum receive message size in bytes used in the config.tom
 ### Description
 
 The Containerd gRPC maximum send message size in bytes used in the config.toml file.
-
-## .spec.kubernetes.advanced.containerd.manageRepositories
-
-### Description
-
-Set to false if you manage the NVIDIA container toolkit's repositories externally and wish to skip their configuration with furyctl. Default is true.
-Notice that containerd itself is installed from binaries and does not use a repository. See `.spec.kubernetes.advanced.airGap` for other download options for containerd.
 
 ## .spec.kubernetes.advanced.containerd.maxContainerLogLineSize
 
@@ -5214,6 +5207,13 @@ Registry address on which you would like to configure authentication or mirror(s
 ### Description
 
 The username containerd will use to authenticate against the registry.
+
+## .spec.kubernetes.advanced.containerd.selfmanagedRepositories
+
+### Description
+
+Set to true if you manage the NVIDIA container toolkit's repositories externally and wish to skip their automatic configuration with furyctl. Default is false (furyctl manages repositories automatically).
+Notice that containerd itself is installed from binaries and does not use a repository. See `.spec.kubernetes.advanced.airGap` for other download options for containerd.
 
 ## .spec.kubernetes.advanced.containerd.stateDir
 
@@ -5419,12 +5419,6 @@ Path to the CA file used to verify the kubelet servers' TLS certificates.
 
 The maximum time a streaming connection can be idle before it is closed. Example: `5m0s`
 
-## .spec.kubernetes.advanced.manageRepositories
-
-### Description
-
-Set to false if you manage the Kubernetes package repositories externally and wish to skip their configuration with furyctl. Default is true.
-
 ## .spec.kubernetes.advanced.oidc
 
 ### Properties
@@ -5490,6 +5484,12 @@ Prefix prepended to username claims to prevent clashes with existing names (such
 ### Description
 
 URL of the registry where to pull images from for the Kubernetes phase. (Default is registry.sighup.io/fury/on-premises).
+
+## .spec.kubernetes.advanced.selfmanagedRepositories
+
+### Description
+
+Set to true if you manage the Kubernetes package repositories externally and wish to skip their automatic configuration with furyctl. Default is false (furyctl manages repositories automatically).
 
 ## .spec.kubernetes.advanced.users
 
@@ -5590,14 +5590,14 @@ A name to identify the etcd node. This value will be concatenated to `.spec.kube
 
 ### Properties
 
-| Property                                                             | Type      | Required |
-|:---------------------------------------------------------------------|:----------|:---------|
-| [additionalConfig](#speckubernetesloadbalancersadditionalconfig)     | `string`  | Optional |
-| [enabled](#speckubernetesloadbalancersenabled)                       | `boolean` | Required |
-| [hosts](#speckubernetesloadbalancershosts)                           | `array`   | Optional |
-| [keepalived](#speckubernetesloadbalancerskeepalived)                 | `object`  | Optional |
-| [manageRepositories](#speckubernetesloadbalancersmanagerepositories) | `boolean` | Optional |
-| [stats](#speckubernetesloadbalancersstats)                           | `object`  | Optional |
+| Property                                                                       | Type      | Required |
+|:-------------------------------------------------------------------------------|:----------|:---------|
+| [additionalConfig](#speckubernetesloadbalancersadditionalconfig)               | `string`  | Optional |
+| [enabled](#speckubernetesloadbalancersenabled)                                 | `boolean` | Required |
+| [hosts](#speckubernetesloadbalancershosts)                                     | `array`   | Optional |
+| [keepalived](#speckubernetesloadbalancerskeepalived)                           | `object`  | Optional |
+| [selfmanagedRepositories](#speckubernetesloadbalancersselfmanagedrepositories) | `boolean` | Optional |
+| [stats](#speckubernetesloadbalancersstats)                                     | `object`  | Optional |
 
 ## .spec.kubernetes.loadBalancers.additionalConfig
 
@@ -5678,11 +5678,11 @@ Password for accessing vrrpd. Make it unique between Keepalived clusters.
 
 The virtual router ID of Keepalived, an arbitrary unique number from 1 to 255 used to differentiate multiple instances of vrrpd running on the same network interface and address family and multicast/unicast (and hence same socket).
 
-## .spec.kubernetes.loadBalancers.manageRepositories
+## .spec.kubernetes.loadBalancers.selfmanagedRepositories
 
 ### Description
 
-Set to false if you manage the HAProxy repositories externally and wish to skip their configuration with furyctl. Default is true.
+Set to true if you manage the HAProxy repositories externally and wish to skip their automatic configuration with furyctl. Default is false (furyctl manages repositories automatically).
 
 ## .spec.kubernetes.loadBalancers.stats
 

--- a/pkg/apis/ekscluster/v1alpha2/private/schema.go
+++ b/pkg/apis/ekscluster/v1alpha2/private/schema.go
@@ -1995,8 +1995,8 @@ const (
 	SpecKubernetesNodePoolTypeSelfManaged SpecKubernetesNodePoolType = "self-managed"
 )
 
-// Additional properties in common for all self-managed node pools. Currently only
-// IMDS properties are supported.
+// Default properties to set for all self-managed and eks-managed node pools.
+// Currently only IMDS properties are supported.
 type SpecKubernetesNodePoolsCommon struct {
 	// Specifies whether the instance metadata service (IMDS) is enabled or disabled.
 	// When set to 'disabled', instance metadata is not accessible.

--- a/pkg/apis/ekscluster/v1alpha2/public/schema.go
+++ b/pkg/apis/ekscluster/v1alpha2/public/schema.go
@@ -1273,8 +1273,8 @@ func (j *SpecKubernetesNodePoolsLaunchKind) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// Additional properties in common for all self-managed node pools. Currently only
-// IMDS properties are supported.
+// Default properties to set for all self-managed and eks-managed node pools.
+// Currently only IMDS properties are supported.
 type SpecKubernetesNodePoolsCommon struct {
 	// Specifies whether the instance metadata service (IMDS) is enabled or disabled.
 	// When set to 'disabled', instance metadata is not accessible.

--- a/pkg/apis/onpremises/v1alpha2/public/schema.go
+++ b/pkg/apis/onpremises/v1alpha2/public/schema.go
@@ -1726,16 +1726,17 @@ type SpecKubernetesAdvanced struct {
 	// "kubeletConfiguration".
 	KubeletConfiguration *SpecKubernetesAdvancedKubeletConfiguration `json:"kubeletConfiguration,omitempty" yaml:"kubeletConfiguration,omitempty" mapstructure:"kubeletConfiguration,omitempty"`
 
-	// Set to false if you manage the Kubernetes package repositories externally and
-	// wish to skip their configuration with furyctl. Default is true.
-	ManageRepositories *bool `json:"manageRepositories,omitempty" yaml:"manageRepositories,omitempty" mapstructure:"manageRepositories,omitempty"`
-
 	// Oidc corresponds to the JSON schema field "oidc".
 	Oidc *SpecKubernetesAdvancedOIDC `json:"oidc,omitempty" yaml:"oidc,omitempty" mapstructure:"oidc,omitempty"`
 
 	// URL of the registry where to pull images from for the Kubernetes phase.
 	// (Default is registry.sighup.io/fury/on-premises).
 	Registry *string `json:"registry,omitempty" yaml:"registry,omitempty" mapstructure:"registry,omitempty"`
+
+	// Set to true if you manage the Kubernetes package repositories externally and
+	// wish to skip their automatic configuration with furyctl. Default is false
+	// (furyctl manages repositories automatically).
+	SelfmanagedRepositories *bool `json:"selfmanagedRepositories,omitempty" yaml:"selfmanagedRepositories,omitempty" mapstructure:"selfmanagedRepositories,omitempty"`
 
 	// Users corresponds to the JSON schema field "users".
 	Users *SpecKubernetesAdvancedUsers `json:"users,omitempty" yaml:"users,omitempty" mapstructure:"users,omitempty"`
@@ -1842,13 +1843,6 @@ type SpecKubernetesAdvancedContainerd struct {
 	// file.
 	GrpcMaxSendMessageSize *int `json:"grpcMaxSendMessageSize,omitempty" yaml:"grpcMaxSendMessageSize,omitempty" mapstructure:"grpcMaxSendMessageSize,omitempty"`
 
-	// Set to false if you manage the NVIDIA container toolkit's repositories
-	// externally and wish to skip their configuration with furyctl. Default is true.
-	// Notice that containerd itself is installed from binaries and does not use a
-	// repository. See `.spec.kubernetes.advanced.airGap` for other download options
-	// for containerd.
-	ManageRepositories *bool `json:"manageRepositories,omitempty" yaml:"manageRepositories,omitempty" mapstructure:"manageRepositories,omitempty"`
-
 	// The maximum container log line size in bytes used in the config.toml file.
 	MaxContainerLogLineSize *int `json:"maxContainerLogLineSize,omitempty" yaml:"maxContainerLogLineSize,omitempty" mapstructure:"maxContainerLogLineSize,omitempty"`
 
@@ -1863,6 +1857,14 @@ type SpecKubernetesAdvancedContainerd struct {
 
 	// RegistryConfigs corresponds to the JSON schema field "registryConfigs".
 	RegistryConfigs SpecKubernetesAdvancedContainerdRegistryConfigs `json:"registryConfigs,omitempty" yaml:"registryConfigs,omitempty" mapstructure:"registryConfigs,omitempty"`
+
+	// Set to true if you manage the NVIDIA container toolkit's repositories
+	// externally and wish to skip their automatic configuration with furyctl. Default
+	// is false (furyctl manages repositories automatically).
+	// Notice that containerd itself is installed from binaries and does not use a
+	// repository. See `.spec.kubernetes.advanced.airGap` for other download options
+	// for containerd.
+	SelfmanagedRepositories *bool `json:"selfmanagedRepositories,omitempty" yaml:"selfmanagedRepositories,omitempty" mapstructure:"selfmanagedRepositories,omitempty"`
 
 	// The Containerd state directory used in the config.toml file.
 	StateDir *string `json:"stateDir,omitempty" yaml:"stateDir,omitempty" mapstructure:"stateDir,omitempty"`
@@ -2084,9 +2086,10 @@ type SpecKubernetesLoadBalancers struct {
 	// Keepalived corresponds to the JSON schema field "keepalived".
 	Keepalived *SpecKubernetesLoadBalancersKeepalived `json:"keepalived,omitempty" yaml:"keepalived,omitempty" mapstructure:"keepalived,omitempty"`
 
-	// Set to false if you manage the HAProxy repositories externally and wish to skip
-	// their configuration with furyctl. Default is true.
-	ManageRepositories *bool `json:"manageRepositories,omitempty" yaml:"manageRepositories,omitempty" mapstructure:"manageRepositories,omitempty"`
+	// Set to true if you manage the HAProxy repositories externally and wish to skip
+	// their automatic configuration with furyctl. Default is false (furyctl manages
+	// repositories automatically).
+	SelfmanagedRepositories *bool `json:"selfmanagedRepositories,omitempty" yaml:"selfmanagedRepositories,omitempty" mapstructure:"selfmanagedRepositories,omitempty"`
 
 	// Stats corresponds to the JSON schema field "stats".
 	Stats *SpecKubernetesLoadBalancersStats `json:"stats,omitempty" yaml:"stats,omitempty" mapstructure:"stats,omitempty"`

--- a/schemas/public/onpremises-kfd-v1alpha2.json
+++ b/schemas/public/onpremises-kfd-v1alpha2.json
@@ -191,9 +191,9 @@
           "type": "string",
           "description": "Additional configuration to append to HAProxy's configuration file."
         },
-        "manageRepositories": {
+        "selfmanagedRepositories": {
           "type": "boolean",
-          "description": "Set to false if you manage the HAProxy repositories externally and wish to skip their configuration with furyctl. Default is true."
+          "description": "Set to true if you manage the HAProxy repositories externally and wish to skip their automatic configuration with furyctl. Default is false (furyctl manages repositories automatically)."
         }
       },
       "required": [
@@ -515,9 +515,9 @@
         "kernelParameters": {
           "$ref": "#/$defs/Spec.Kubernetes.Advanced.KernelParameters"
         },
-        "manageRepositories": {
+        "selfmanagedRepositories": {
           "type": "boolean",
-          "description": "Set to false if you manage the Kubernetes package repositories externally and wish to skip their configuration with furyctl. Default is true."
+          "description": "Set to true if you manage the Kubernetes package repositories externally and wish to skip their automatic configuration with furyctl. Default is false (furyctl manages repositories automatically)."
         },
         "controllerManager": {
           "$ref": "#/$defs/Spec.Kubernetes.Advanced.ControllerManager"
@@ -626,9 +626,9 @@
         "registryConfigs": {
           "$ref": "#/$defs/Spec.Kubernetes.Advanced.Containerd.RegistryConfigs"
         },
-        "manageRepositories": {
+        "selfmanagedRepositories": {
           "type": "boolean",
-          "description": "Set to false if you manage the NVIDIA container toolkit's repositories externally and wish to skip their configuration with furyctl. Default is true.\nNotice that containerd itself is installed from binaries and does not use a repository. See `.spec.kubernetes.advanced.airGap` for other download options for containerd."
+          "description": "Set to true if you manage the NVIDIA container toolkit's repositories externally and wish to skip their automatic configuration with furyctl. Default is false (furyctl manages repositories automatically).\nNotice that containerd itself is installed from binaries and does not use a repository. See `.spec.kubernetes.advanced.airGap` for other download options for containerd."
         },
         "storageDir": {
           "type": "string",

--- a/templates/kubernetes/onpremises/hosts.yaml.tpl
+++ b/templates/kubernetes/onpremises/hosts.yaml.tpl
@@ -18,7 +18,7 @@ all:
         keepalived_virtual_router_id: "{{ .spec.kubernetes.loadBalancers.keepalived.virtualRouterId }}"
         keepalived_passphrase: "{{ .spec.kubernetes.loadBalancers.keepalived.passphrase }}"
         {{- if hasKeyAny .spec.kubernetes.loadBalancers "selfmanagedRepositories" }}
-        haproxy_selfmanaged_repositories: {{ .spec.kubernetes.loadBalancers.selfmanagedRepositories }}
+        haproxy_self_managed_repositories: {{ .spec.kubernetes.loadBalancers.selfmanagedRepositories }}
         {{- end }}
     {{- end }}
     master:
@@ -270,7 +270,7 @@ all:
       {{- end }}
     {{- end }}
     {{- if hasKeyAny .spec.kubernetes.advanced.containerd "selfmanagedRepositories" }}
-    containerd_selfmanaged_repositories: {{ .spec.kubernetes.advanced.containerd.selfmanagedRepositories }}
+    containerd_self_managed_repositories: {{ .spec.kubernetes.advanced.containerd.selfmanagedRepositories }}
     {{- end }}
     {{- if hasKeyAny .spec.kubernetes.advanced.containerd "storageDir" }}
     containerd_storage_dir: "{{ .spec.kubernetes.advanced.containerd.storageDir }}"
@@ -361,7 +361,7 @@ all:
     {{- end -}}
 
     {{- if hasKeyAny .spec.kubernetes.advanced "selfmanagedRepositories" }}
-    kubernetes_selfmanaged_repositories: {{ .spec.kubernetes.advanced.selfmanagedRepositories }}
+    kubernetes_self_managed_repositories: {{ .spec.kubernetes.advanced.selfmanagedRepositories }}
     {{- end }}
 
     {{- end }}

--- a/templates/kubernetes/onpremises/hosts.yaml.tpl
+++ b/templates/kubernetes/onpremises/hosts.yaml.tpl
@@ -17,8 +17,8 @@ all:
         keepalived_ip: "{{ .spec.kubernetes.loadBalancers.keepalived.ip }}"
         keepalived_virtual_router_id: "{{ .spec.kubernetes.loadBalancers.keepalived.virtualRouterId }}"
         keepalived_passphrase: "{{ .spec.kubernetes.loadBalancers.keepalived.passphrase }}"
-        {{- if hasKeyAny .spec.kubernetes.loadBalancers "manageRepositories" }}
-        haproxy_manage_repositories: {{ .spec.kubernetes.loadBalancers.manageRepositories }}
+        {{- if hasKeyAny .spec.kubernetes.loadBalancers "selfmanagedRepositories" }}
+        haproxy_selfmanaged_repositories: {{ .spec.kubernetes.loadBalancers.selfmanagedRepositories }}
         {{- end }}
     {{- end }}
     master:
@@ -269,8 +269,8 @@ all:
         {{- end }}
       {{- end }}
     {{- end }}
-    {{- if hasKeyAny .spec.kubernetes.advanced.containerd "manageRepositories" }}
-    containerd_manage_repositories: {{ .spec.kubernetes.advanced.containerd.manageRepositories }}
+    {{- if hasKeyAny .spec.kubernetes.advanced.containerd "selfmanagedRepositories" }}
+    containerd_selfmanaged_repositories: {{ .spec.kubernetes.advanced.containerd.selfmanagedRepositories }}
     {{- end }}
     {{- if hasKeyAny .spec.kubernetes.advanced.containerd "storageDir" }}
     containerd_storage_dir: "{{ .spec.kubernetes.advanced.containerd.storageDir }}"
@@ -360,8 +360,8 @@ all:
       {{ .spec.kubernetes.advanced.kernelParameters | toYaml | indent 6 | trim }}
     {{- end -}}
 
-    {{- if hasKeyAny .spec.kubernetes.advanced "manageRepositories" }}
-    kubernetes_manage_repositories: {{ .spec.kubernetes.advanced.manageRepositories }}
+    {{- if hasKeyAny .spec.kubernetes.advanced "selfmanagedRepositories" }}
+    kubernetes_selfmanaged_repositories: {{ .spec.kubernetes.advanced.selfmanagedRepositories }}
     {{- end }}
 
     {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request.

By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull
request to the best possible team for review.

💡 **TIP**
Remember that you can always open a PR in draft status and fill all the information afterwards.

Opening a PR in draft allows other team members to know that you are working on this change, and let's you have a
place to track your work in progress.

When opening PRs in Draft, **don't assign reviewers until the PR is ready for review**.

Once you are confortable with the status of the PR and all the tests and CI is green, you can assign the reviewers to start the review process.
-->

### Summary 💡

Refactor repository management configuration fields to eliminate ambiguity. Changes `manageRepositories` to `selfmanagedRepositories` with inverted logic to make the field name more descriptive.

Relates: [sighupio/distribution/pull/444](https://github.com/sighupio/distribution/pull/444)

### Description 📝

- Renamed `manageRepositories` to `selfmanagedRepositories`
- Inverted logic:
  - `selfmanagedRepositories: false` (default) when furyctl manages repositories automatically
  - `selfmanagedRepositories: true` when user manages repositories externally

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] Tested the change with SD version v1.33.0-rc.2
- [x] Checked backward compatibility with existing fields


### Future work 🔧

None.
