### PR TITLE
feat: remove nested index calls and replace with new hasField and getFieldOrDefault

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -17,7 +17,7 @@ python = "3.12"
 pipx = "latest"
 ansible = "latest"
 awscli = "2.24.17"
-furyctl = "0.33.2-rc.1"
+furyctl = "0.33.2-rc.2"
 
 # Go packages (using go: backend)
 "go:github.com/evanphx/json-patch/v5/cmd/json-patch" = "v5.9.0"

--- a/templates/distribution/manifests/auth/resources/pomerium-policy.yml.tpl
+++ b/templates/distribution/manifests/auth/resources/pomerium-policy.yml.tpl
@@ -14,7 +14,7 @@ routes:
   - from: https://{{ template "prometheusUrl" .spec }}
     to: http://prometheus-k8s.monitoring.svc.cluster.local:9090
     policy:
-      {{- if and (index .spec.distribution.modules.auth.pomerium "defaultRoutesPolicy") (index .spec.distribution.modules.auth.pomerium.defaultRoutesPolicy "monitoringPrometheus") }}
+      {{- if hasField . "spec.distribution.modules.auth.pomerium.defaultRoutesPolicy.monitoringPrometheus" }}
       {{- .spec.distribution.modules.auth.pomerium.defaultRoutesPolicy.monitoringPrometheus | toYaml | nindent 6 }}
       {{- else }}
       - allow:
@@ -24,7 +24,7 @@ routes:
   - from: https://{{ template "alertmanagerUrl" .spec }}
     to: http://alertmanager-main.monitoring.svc.cluster.local:9093
     policy:
-      {{- if and (index .spec.distribution.modules.auth.pomerium "defaultRoutesPolicy") (index .spec.distribution.modules.auth.pomerium.defaultRoutesPolicy "monitoringAlertmanager") }}
+      {{- if hasField . "spec.distribution.modules.auth.pomerium.defaultRoutesPolicy.monitoringAlertmanager" }}
       {{- .spec.distribution.modules.auth.pomerium.defaultRoutesPolicy.monitoringAlertmanager | toYaml | nindent 6 }}
       {{- else }}
       - allow:
@@ -38,7 +38,7 @@ routes:
     preserve_host_header: true
     pass_identity_headers: true
     policy:
-      {{- if and (index .spec.distribution.modules.auth.pomerium "defaultRoutesPolicy") (index .spec.distribution.modules.auth.pomerium.defaultRoutesPolicy "monitoringGrafana") }}
+      {{- if hasField . "spec.distribution.modules.auth.pomerium.defaultRoutesPolicy.monitoringGrafana" }}
       {{- .spec.distribution.modules.auth.pomerium.defaultRoutesPolicy.monitoringGrafana | toYaml | nindent 6 }}
       {{- else }}
       - allow:
@@ -51,7 +51,7 @@ routes:
     allow_websockets: true
     preserve_host_header: true
     policy:
-      {{- if and (index .spec.distribution.modules.auth.pomerium "defaultRoutesPolicy") (index .spec.distribution.modules.auth.pomerium.defaultRoutesPolicy "monitoringMinioConsole") }}
+      {{- if hasField . "spec.distribution.modules.auth.pomerium.defaultRoutesPolicy.monitoringMinioConsole" }}
       {{- .spec.distribution.modules.auth.pomerium.defaultRoutesPolicy.monitoringMinioConsole | toYaml | nindent 6 }}
       {{- else }}
       - allow:
@@ -65,7 +65,7 @@ routes:
   - from: https://{{ template "forecastleUrl" .spec }}
     to: http://forecastle.ingress-nginx.svc.cluster.local
     policy:
-      {{- if and (index .spec.distribution.modules.auth.pomerium "defaultRoutesPolicy") (index .spec.distribution.modules.auth.pomerium.defaultRoutesPolicy "ingressNgnixForecastle") }}
+      {{- if hasField . "spec.distribution.modules.auth.pomerium.defaultRoutesPolicy.ingressNgnixForecastle" }}
       {{- .spec.distribution.modules.auth.pomerium.defaultRoutesPolicy.ingressNgnixForecastle | toYaml | nindent 6 }}
       {{- else }}
       - allow:
@@ -79,7 +79,7 @@ routes:
   - from: https://{{ template "opensearchDashboardsUrl" .spec }}
     to: http://opensearch-dashboards.logging.svc.cluster.local:5601
     policy:
-      {{- if and (index .spec.distribution.modules.auth.pomerium "defaultRoutesPolicy") (index .spec.distribution.modules.auth.pomerium.defaultRoutesPolicy "loggingOpensearchDashboards") }}
+      {{- if hasField . "spec.distribution.modules.auth.pomerium.defaultRoutesPolicy.loggingOpensearchDashboards" }}
       {{- .spec.distribution.modules.auth.pomerium.defaultRoutesPolicy.loggingOpensearchDashboards | toYaml | nindent 6 }}
       {{- else }}
       - allow:
@@ -92,7 +92,7 @@ routes:
     allow_websockets: true
     preserve_host_header: true
     policy:
-      {{- if and (index .spec.distribution.modules.auth.pomerium "defaultRoutesPolicy") (index .spec.distribution.modules.auth.pomerium.defaultRoutesPolicy "loggingMinioConsole") }}
+      {{- if hasField . "spec.distribution.modules.auth.pomerium.defaultRoutesPolicy.loggingMinioConsole" }}
       {{- .spec.distribution.modules.auth.pomerium.defaultRoutesPolicy.loggingMinioConsole | toYaml | nindent 6 }}
       {{- else }}
       - allow:
@@ -106,7 +106,7 @@ routes:
     allow_websockets: true
     preserve_host_header: true
     policy:
-      {{- if and (index .spec.distribution.modules.auth.pomerium "defaultRoutesPolicy") (index .spec.distribution.modules.auth.pomerium.defaultRoutesPolicy "tracingMinioConsole") }}
+      {{- if hasField . "spec.distribution.modules.auth.pomerium.defaultRoutesPolicy.tracingMinioConsole" }}
       {{- .spec.distribution.modules.auth.pomerium.defaultRoutesPolicy.tracingMinioConsole | toYaml | nindent 6 }}
       {{- else }}
       - allow:
@@ -119,7 +119,7 @@ routes:
   - from: https://{{ template "gpmUrl" .spec }}
     to: http://gatekeeper-policy-manager.gatekeeper-system.svc.cluster.local
     policy:
-      {{- if and (index .spec.distribution.modules.auth.pomerium "defaultRoutesPolicy") (index .spec.distribution.modules.auth.pomerium.defaultRoutesPolicy "gatekeeperPolicyManager") }}
+      {{- if hasField . "spec.distribution.modules.auth.pomerium.defaultRoutesPolicy.gatekeeperPolicyManager" }}
       {{- .spec.distribution.modules.auth.pomerium.defaultRoutesPolicy.gatekeeperPolicyManager | toYaml | nindent 6 }}
       {{- else }}
       - allow:
@@ -132,7 +132,7 @@ routes:
   - from: https://{{ template "hubbleUrl" .spec }}
     to: http://hubble-ui.kube-system.svc.cluster.local
     policy:
-      {{- if and (index .spec.distribution.modules.auth.pomerium "defaultRoutesPolicy") (index .spec.distribution.modules.auth.pomerium.defaultRoutesPolicy "hubbleUi") }}
+      {{- if hasField . "spec.distribution.modules.auth.pomerium.defaultRoutesPolicy.hubbleUi" }}
       {{- .spec.distribution.modules.auth.pomerium.defaultRoutesPolicy.hubbleUi | toYaml | nindent 6 }}
       {{- else }}
       - allow:

--- a/templates/distribution/manifests/logging/kustomization.yaml.tpl
+++ b/templates/distribution/manifests/logging/kustomization.yaml.tpl
@@ -67,7 +67,7 @@ patches:
   {{- if eq $loggingType "opensearch" }}
   - path: patches/opensearch.yml
   {{- /* The patch file below can be empty when loki resources is not defined but kustomize 5.6.0 (our current version) fails when a patch file is empty, so we need to apply it conditionally. */ -}}
-  {{- else if hasKeyAny $loki "resources" }}
+  {{- else if hasField . "spec.distribution.modules.logging.loki.resources" }}
   - path: patches/loki-resources.yml
   {{- end }}
 {{- end }}

--- a/templates/distribution/manifests/logging/patches/loki-config.yaml.tpl
+++ b/templates/distribution/manifests/logging/patches/loki-config.yaml.tpl
@@ -98,8 +98,8 @@ schema_config:
     object_store: s3
     schema: v11
     store: boltdb-shipper
-{{- if and (index .spec.distribution.modules.logging "loki") (index .spec.distribution.modules.logging.loki "tsdbStartDate") }}
-  - from: "{{ .spec.distribution.modules.logging.loki.tsdbStartDate }}" 
+{{- if hasField . "spec.distribution.modules.logging.loki.tsdbStartDate" }}
+  - from: "{{ .spec.distribution.modules.logging.loki.tsdbStartDate }}"
     index:
       period: 24h
       prefix: index_

--- a/templates/distribution/manifests/logging/patches/loki-resources.yml.tpl
+++ b/templates/distribution/manifests/logging/patches/loki-resources.yml.tpl
@@ -1,6 +1,5 @@
-{{- $package := index .spec.distribution.modules.logging "loki" -}}
-
-{{- if and (eq .spec.distribution.modules.logging.type "loki") (hasKeyAny $package "resources") }}
+{{- if and (eq .spec.distribution.modules.logging.type "loki") (hasField . "spec.distribution.modules.logging.loki.resources") }}
+{{- $resources := .spec.distribution.modules.logging.loki.resources }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -13,7 +12,7 @@ spec:
       containers:
       - name: ingester
         resources:
-          {{ $package.resources | toYaml | indent 10 | trim }}
+          {{ $resources | toYaml | indent 10 | trim }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -26,7 +25,7 @@ spec:
       containers:
       - name: compactor
         resources:
-          {{ $package.resources | toYaml | indent 10 | trim }}
+          {{ $resources | toYaml | indent 10 | trim }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -39,7 +38,7 @@ spec:
       containers:
       - name: distributor
         resources:
-          {{ $package.resources | toYaml | indent 10 | trim }}
+          {{ $resources | toYaml | indent 10 | trim }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -52,7 +51,7 @@ spec:
       containers:
       - name: nginx
         resources:
-          {{ $package.resources | toYaml | indent 10 | trim }}
+          {{ $resources | toYaml | indent 10 | trim }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -65,7 +64,7 @@ spec:
       containers:
       - name: query-frontend
         resources:
-          {{ $package.resources | toYaml | indent 10 | trim }}
+          {{ $resources | toYaml | indent 10 | trim }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -78,7 +77,7 @@ spec:
       containers:
       - name: querier
         resources:
-          {{ $package.resources | toYaml | indent 10 | trim }}
+          {{ $resources | toYaml | indent 10 | trim }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -91,7 +90,7 @@ spec:
       containers:
       - name: query-scheduler
         resources:
-          {{ $package.resources | toYaml | indent 10 | trim }}
+          {{ $resources | toYaml | indent 10 | trim }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -104,5 +103,5 @@ spec:
       containers:
       - name: index-gateway
         resources:
-          {{ $package.resources | toYaml | indent 10 | trim }}
+          {{ $resources | toYaml | indent 10 | trim }}
 {{- end }}

--- a/templates/distribution/manifests/logging/patches/opensearch.yml.tpl
+++ b/templates/distribution/manifests/logging/patches/opensearch.yml.tpl
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: opensearch
-      {{- if hasKeyAny .spec.distribution.modules.logging.opensearch "resources" }}
+      {{- if hasField . "spec.distribution.modules.logging.opensearch.resources" }}
         resources:
           {{ .spec.distribution.modules.logging.opensearch.resources | toYaml | indent 10 | trim }}
       {{- end }}

--- a/templates/distribution/manifests/monitoring/kustomization.yaml.tpl
+++ b/templates/distribution/manifests/monitoring/kustomization.yaml.tpl
@@ -21,11 +21,9 @@ resources:
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/monitoring/katalog/blackbox-exporter" }}
 {{- if eq .spec.distribution.common.provider.type "none" }}{{/* none === on-premises and kfddistribution */}}
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/monitoring/katalog/kubeadm-sm" }}
-  {{- if hasKeyAny .spec "kubernetes" }}
-    {{- if .spec.kubernetes.loadBalancers.enabled }}
+  {{- if getFieldOrDefault . "spec.kubernetes.loadBalancers.enabled" false }}
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/monitoring/katalog/haproxy" }}
   - resources/haproxy-scrapeConfig.yaml
-    {{- end }}
   {{- end }}
 {{- end }}
 {{- if eq .spec.distribution.common.provider.type "eks" }}

--- a/templates/distribution/manifests/monitoring/patches/grafana.ini.tpl
+++ b/templates/distribution/manifests/monitoring/patches/grafana.ini.tpl
@@ -13,7 +13,7 @@ auto_sign_up = true
 [users]
 auto_assign_org = true
 viewers_can_edit =  true
-{{- if and (index .spec.distribution.modules.monitoring "grafana") (index .spec.distribution.modules.monitoring.grafana "usersRoleAttributePath") }}
+{{- if hasField . "spec.distribution.modules.monitoring.grafana.usersRoleAttributePath" }}
 [auth.jwt]
 role_attribute_path = {{ .spec.distribution.modules.monitoring.grafana.usersRoleAttributePath }}
 {{- else }}

--- a/templates/distribution/manifests/monitoring/patches/prometheus-operated.yml.tpl
+++ b/templates/distribution/manifests/monitoring/patches/prometheus-operated.yml.tpl
@@ -12,11 +12,11 @@ spec:
   externalLabels:
     k8s_cluster: {{ .metadata.name }}
   externalUrl: https://{{ template "prometheusUrl" .spec }}
-  {{- if hasKeyAny .spec.distribution.modules.monitoring.prometheus "resources" }}
+  {{- if hasField . "spec.distribution.modules.monitoring.prometheus.resources" }}
   resources:
     {{ .spec.distribution.modules.monitoring.prometheus.resources | toYaml | indent 4 | trim }}
   {{- end }}
-  {{- if hasKeyAny .spec.distribution.modules.monitoring.prometheus "remoteWrite" }}
+  {{- if hasField . "spec.distribution.modules.monitoring.prometheus.remoteWrite" }}
   remoteWrite:
     {{ .spec.distribution.modules.monitoring.prometheus.remoteWrite | toYaml | indent 4 | trim }}
   {{- end }}

--- a/templates/distribution/manifests/monitoring/resources/haproxy-scrapeConfig.yaml.tpl
+++ b/templates/distribution/manifests/monitoring/resources/haproxy-scrapeConfig.yaml.tpl
@@ -1,7 +1,5 @@
 
-{{- if eq .spec.distribution.common.provider.type "none" }}
-{{- if hasKeyAny .spec "kubernetes" }}
-{{- if .spec.kubernetes.loadBalancers.enabled }}
+{{- if and (eq .spec.distribution.common.provider.type "none") (getFieldOrDefault . "spec.kubernetes.loadBalancers.enabled" false) }}
 ---
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: ScrapeConfig
@@ -18,6 +16,4 @@ spec:
         {{- range $lb := .spec.kubernetes.loadBalancers.hosts }}
         - {{ $lb.ip }}:8405
         {{- end }}
-{{- end }}
-{{- end }}
 {{- end }}

--- a/templates/distribution/manifests/monitoring/resources/ingress-infra.yml.tpl
+++ b/templates/distribution/manifests/monitoring/resources/ingress-infra.yml.tpl
@@ -185,8 +185,7 @@ spec:
 {{- end }}
 {{- end }}
 
-{{- if and (index .spec.distribution.modules.monitoring "grafana") (index .spec.distribution.modules.monitoring.grafana "basicAuthIngress") }}
-{{- if .spec.distribution.modules.monitoring.grafana.basicAuthIngress }}
+{{- if getFieldOrDefault . "spec.distribution.modules.monitoring.grafana.basicAuthIngress" false }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -209,5 +208,4 @@ spec:
                 port:
                   name: http
 {{- template "ingressTls" (dict "module" "monitoring" "package" "grafanaBasicAuth" "prefix" "grafana-basic-auth." "spec" .spec) }}
-{{- end }}
 {{- end }}

--- a/templates/distribution/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml.tpl
+++ b/templates/distribution/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml.tpl
@@ -14,12 +14,12 @@ spec:
   replicas: 2
   externalLabels:
     k8s_cluster: {{ .metadata.name }}
-  {{- if hasKeyAny .spec.distribution.modules.monitoring.prometheusAgent "resources" }}
+  {{- if hasField . "spec.distribution.modules.monitoring.prometheusAgent.resources" }}
   resources:
     {{ .spec.distribution.modules.monitoring.prometheusAgent.resources | toYaml | indent 4 | trim }}
   {{- end }}
 
-  {{- if hasKeyAny .spec.distribution.modules.monitoring.prometheusAgent "remoteWrite" }}
+  {{- if hasField . "spec.distribution.modules.monitoring.prometheusAgent.remoteWrite" }}
   remoteWrite:
     {{ .spec.distribution.modules.monitoring.prometheusAgent.remoteWrite | toYaml | indent 4 | trim }}
   {{- end }}

--- a/templates/distribution/manifests/networking/patches/cilium/cilium-config.env.tpl
+++ b/templates/distribution/manifests/networking/patches/cilium/cilium-config.env.tpl
@@ -1,12 +1,10 @@
 {{- if eq .spec.distribution.common.provider.type "none"  }}
 cluster-pool-ipv4-mask-size={{ .spec.distribution.modules.networking.cilium.maskSize }}
-    {{- if and (index .spec "kubernetes") (index .spec.kubernetes "podCidr") }}
-        {{- if .spec.distribution.modules.networking.cilium.podCidr }}
+{{- if .spec.distribution.modules.networking.cilium.podCidr }}
 cluster-pool-ipv4-cidr={{ .spec.distribution.modules.networking.cilium.podCidr }}
-        {{- else }}
+{{- else if hasField . "spec.kubernetes.podCidr" }}
 cluster-pool-ipv4-cidr={{ .spec.kubernetes.podCidr }}
-        {{- end }}
-    {{- else }}
+{{- else }}
 cluster-pool-ipv4-cidr={{ .spec.distribution.modules.networking.cilium.podCidr }}
-    {{- end }}
+{{- end }}
 {{- end }}

--- a/templates/distribution/scripts/pre-apply.sh.tpl
+++ b/templates/distribution/scripts/pre-apply.sh.tpl
@@ -426,12 +426,8 @@ deleteMonitoringCommon() {
   $kustomizebin build $vendorPath/modules/monitoring/katalog/kube-state-metrics | $kubectlbin delete --ignore-not-found --wait --timeout=600s -f -
   $kustomizebin build $vendorPath/modules/monitoring/katalog/node-exporter | $kubectlbin delete --ignore-not-found --wait --timeout=600s -f -
   $kustomizebin build $vendorPath/modules/monitoring/katalog/x509-exporter | $kubectlbin delete --ignore-not-found --wait --timeout=600s -f -
-  {{- if eq .spec.distribution.common.provider.type "none" }}
-  {{- if hasKeyAny .spec "kubernetes" }}
-  {{- if .spec.kubernetes.loadBalancers.enabled }}
+  {{- if and (eq .spec.distribution.common.provider.type "none") (getFieldOrDefault . "spec.kubernetes.loadBalancers.enabled" false) }}
   $kustomizebin build $vendorPath/modules/monitoring/katalog/haproxy | $kubectlbin delete --ignore-not-found --wait --timeout=600s -f -
-  {{- end }}
-  {{- end }}
   {{- end }}
   echo "Monitoring common resources deleted."
 }

--- a/templates/distribution/terraform/cluster-autoscaler.tf.tpl
+++ b/templates/distribution/terraform/cluster-autoscaler.tf.tpl
@@ -13,10 +13,7 @@ module "cluster_autoscaler_iam_role" {
   source       = "{{ print .spec.distribution.common.relativeVendorPath "/modules/aws/modules/iam-for-cluster-autoscaler" }}"
   cluster_name = "{{ .metadata.name }}"
   region       = "{{ $region }}"
-  {{- if and (hasKeyAny .spec.distribution.modules "aws")
-   (hasKeyAny .spec.distribution.modules.aws "clusterAutoscaler")
-   (hasKeyAny .spec.distribution.modules.aws.clusterAutoscaler "overrides")
-   (hasKeyAny .spec.distribution.modules.aws.clusterAutoscaler.overrides "iamRoleName") }}
+  {{- if hasField . "spec.distribution.modules.aws.clusterAutoscaler.overrides.iamRoleName" }}
   autoscaler_iam_role_name_override = "{{ .spec.distribution.modules.aws.clusterAutoscaler.overrides.iamRoleName }}"
   {{- end }}
 }

--- a/templates/distribution/terraform/ebs-csi-driver.tf.tpl
+++ b/templates/distribution/terraform/ebs-csi-driver.tf.tpl
@@ -5,10 +5,7 @@
 module "ebs_csi_driver_iam_role" {
   source       = "{{ print .spec.distribution.common.relativeVendorPath "/modules/aws/modules/iam-for-ebs-csi-driver" }}"
   cluster_name = "{{ .metadata.name }}"
-  {{- if and (hasKeyAny .spec.distribution.modules "aws")
-   (hasKeyAny .spec.distribution.modules.aws "ebsCsiDriver")
-   (hasKeyAny .spec.distribution.modules.aws.ebsCsiDriver "overrides")
-   (hasKeyAny .spec.distribution.modules.aws.ebsCsiDriver.overrides "iamRoleName") }}
+  {{- if hasField . "spec.distribution.modules.aws.ebsCsiDriver.overrides.iamRoleName" }}
   ebs_iam_role_name_override = "{{ .spec.distribution.modules.aws.ebsCsiDriver.overrides.iamRoleName }}"
   {{- end }}
 }

--- a/templates/distribution/terraform/load-balancer-controller.tf.tpl
+++ b/templates/distribution/terraform/load-balancer-controller.tf.tpl
@@ -5,10 +5,7 @@
 module "load_balancer_controller_iam_role" {
   source       = "{{ print .spec.distribution.common.relativeVendorPath "/modules/aws/modules/iam-for-load-balancer-controller" }}"
   cluster_name = "{{ .metadata.name }}"
-  {{- if and (hasKeyAny .spec.distribution.modules "aws")
-   (hasKeyAny .spec.distribution.modules.aws "loadBalancerController")
-   (hasKeyAny .spec.distribution.modules.aws.loadBalancerController "overrides")
-   (hasKeyAny .spec.distribution.modules.aws.loadBalancerController.overrides "iamRoleName") }}
+  {{- if hasField . "spec.distribution.modules.aws.loadBalancerController.overrides.iamRoleName" }}
   lb_iam_role_name_override = "{{ .spec.distribution.modules.aws.loadBalancerController.overrides.iamRoleName }}"
   {{- end }}
 }


### PR DESCRIPTION
### Summary 💡

Refactored 16 template files across 6 modules (Terraform, Pomerium, Monitoring, Logging, Networking, Scripts) using new `hasField` and `getFieldOrDefault` functions from furyctl v0.33.2-rc.2. Reduced 3-5 level nested conditionals to 1-2 levels while preserving exact logical behavior. Template conditions now clearly show full field paths being checked, improving readability and maintainability.

### Breaking Changes 💔

- Template incompatible with older furyctl versions (but it's something that is accepted)

### Tests performed 🧪

- [ ] e2e with kfddistribution