### PR TITLE
feat(kfd): add ansible tool for the self-contained portable bundle

### DIFF
--- a/kfd.yaml
+++ b/kfd.yaml
@@ -56,6 +56,11 @@ tools:
       version: 0.65.0
     ansible:
       version: v0.2.1
+      checksums:
+        linux-amd64: "7fcb1e397872579b7c05bc87a47d531025d362b421d3bcae337a748256733d89"
+        linux-arm64: "f8022d2a8cbfa2a66c2a9b1883d35d848438cfff27e81b0c22df92657bdfa796"
+        darwin-amd64: "1cfd1fb4facc3e485d7df93535dea5853320b67326c171361f6d329b7e83d0e0"
+        darwin-arm64: "2f7a5cf81125f1f127eb709128fd92a179ed473fc60fd29633ef95536b6bc5e7"
   eks:
     awscli:
       version: ">= 2.8.12"

--- a/kfd.yaml
+++ b/kfd.yaml
@@ -54,6 +54,8 @@ tools:
       version: 1.2.3
     kapp:
       version: 0.65.0
+    ansible:
+      version: v0.2.1
   eks:
     awscli:
       version: ">= 2.8.12"

--- a/pkg/apis/config/model.go
+++ b/pkg/apis/config/model.go
@@ -74,6 +74,7 @@ type KFDToolsCommon struct {
 	Kapp      KFDTool `yaml:"kapp"`
 	Helm      KFDTool `yaml:"helm"`
 	Helmfile  KFDTool `yaml:"helmfile"`
+	Ansible   KFDTool `yaml:"ansible"`
 }
 
 type KFDToolsEks struct {


### PR DESCRIPTION
### Summary 💡

Adds `ansible` as a managed KFD tool (with per-arch checksums) so that `furyctl` can download a self-contained, versioned, **integrity-verified** Ansible bundle instead of requiring Ansible to be pre-installed on the host.

Related furyctl PR: https://github.com/sighupio/furyctl/pull/671
Reference PoC (bundle build recipe + releases): https://github.com/nutellinoit/ansible-portable-poc (release `v0.2.1`)

### Description 📝

On-premises (and Immutable) provisioning relies on Ansible, which today must be installed and versioned by hand on the operator machine. This makes it a managed, reproducible dependency like every other tool:

- New `KFDToolsCommon.Ansible` field in `pkg/apis/config/model.go` (optional → older furyctl/distros unaffected).
- `tools.common.ansible.version` pinned in `kfd.yaml`.
- `tools.common.ansible.checksums` pins the per-arch **SHA-256** (keyed `<os>-<arch>`) of each bundle tarball; furyctl verifies the download against it.
- The pinned version is the **bundle release tag**, decoupled from the ansible-core version (rebuild at the same ansible-core by bumping the release).
- `model.go` is hand-written (not generated), so no regeneration is required; `KFDTool.Checksums` already existed.

### Breaking Changes 💔

None — the fields are optional; distros without them keep the previous behavior (system Ansible, no checksum).

### Tests performed 🧪

- [x] furyctl downloads and runs the bundle from this field (on-prem e2e, cluster created)
- [x] furyctl verifies the pinned per-arch SHA-256 on download; a wrong hash fails the download
- [x] Distros without the field fall back to system Ansible

### Next steps 🔜

- If we adopt this, **internalize the Ansible PoC** into a SIGHUP-hosted bundle repo (build recipe + release pipeline) and host the artifacts under SIGHUP.
- Cut a proper `fury-distribution` release including these fields (pre-release `v1.34.2-rc.1` was pushed for furyctl to consume in the meantime).
