### PR TITLE
fix(on-prem): propagate kubernetes_image_registry to worker and etcd nodes

### DIFF
--- a/templates/kubernetes/onpremises/hosts.yaml.tpl
+++ b/templates/kubernetes/onpremises/hosts.yaml.tpl
@@ -176,6 +176,9 @@ all:
       vars:
         dns_zone: "{{ $dnsZone }}"
         etcd_initial_cluster: "{{ $etcdInitialCluster | join "," }}"
+        {{- if and (index .spec.kubernetes "advanced") (index .spec.kubernetes.advanced "registry") (ne .spec.kubernetes.advanced.registry "") }}
+        kubernetes_image_registry: "{{ .spec.kubernetes.advanced.registry }}"
+        {{- end }}
         {{- else }}
         {{- range $h := .spec.kubernetes.masters.hosts }}
         {{ $h.name }}:
@@ -232,6 +235,10 @@ all:
               {{ $n.kernelParameters | toYaml | indent 14 | trim }}
             {{- end -}}
 
+      {{- end }}
+      {{- if and (index .spec.kubernetes "advanced") (index .spec.kubernetes.advanced "registry") (ne .spec.kubernetes.advanced.registry "") }}
+      vars:
+        kubernetes_image_registry: "{{ .spec.kubernetes.advanced.registry }}"
       {{- end }}
     ungrouped: {}
   vars:


### PR DESCRIPTION
### Summary 💡

On-prem clusters with a custom registry (`spec.kubernetes.advanced.registry`): worker/infra nodes were pulling the `pause` image from the default registry instead.

Closes: #523

### Description 📝

`kubernetes_image_registry` was set only under the `master` group vars in the generated `hosts.yaml`, so worker/infra and external etcd nodes fell back to the hardcoded `registry.sighup.io/fury/on-premises` for `sandbox_image`. Added it to the `nodes` and external-`etcd` group vars too. Left out of `haproxy` on purpose (L4 LB, not a cluster node).

### Breaking Changes 💔

None. With `advanced.registry` unset the output is unchanged.

### Tests performed 🧪

- [x] Template structure checked (mirrors the existing `master` block).

### Future work 🔧

None.
