### PR TITLE
feat(immutable/butane): render storage.additionalDisks on all node roles

### DIFF
--- a/templates/infrastructure/immutable/butane/_helpers.tpl
+++ b/templates/infrastructure/immutable/butane/_helpers.tpl
@@ -99,6 +99,49 @@ passwd:
 {{- end }}
 {{- end }}
 
+{{- /*
+  User-provided additional disks: storage.disks + storage.filesystems + mount units.
+  Shared by every role — the schema puts additionalDisks on Node.Storage, which all four
+  roles share, so a role that omitted this block would accept the config and silently
+  drop it. Unlike network or systemd config, this cannot be worked around with
+  storage.files: Ignition runs disks -> filesystems -> files, so files are written after
+  the filesystem is already mounted and cannot partition a device.
+*/}}
+{{- define "additional-disks" }}
+{{- if hasKeyAny .node.storage "additionalDisks" }}
+  disks:
+{{- range .node.storage.additionalDisks }}
+    - device: {{ .device }}
+      wipe_table: true
+      partitions:
+{{- range .partitions }}
+        - label: {{ .label }}
+          number: {{ .number }}
+{{- if .sizeMiB }}
+          size_mib: {{ .sizeMiB }}
+{{- end }}
+{{- end }}
+{{- end }}
+  filesystems:
+{{- range .node.storage.additionalDisks }}
+{{- range .partitions }}
+    - device: /dev/disk/by-partlabel/{{ .label }}
+      format: {{ .filesystem.format }}
+      label: {{ .filesystem.label }}
+      path: {{ .filesystem.mountPoint }}
+      wipe_filesystem: true
+      with_mount_unit: true
+{{- if hasKeyAny .filesystem "mountOptions" }}
+      mount_options:
+{{- range .filesystem.mountOptions }}
+        - {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
 {{- define "containerd-sysext-files" }}
     # containerd sysext download and sysupdate configuration
     - path: /opt/extensions/containerd/containerd-{{ .sysext.containerd.version }}-{{ .node.arch }}.raw

--- a/templates/infrastructure/immutable/butane/_helpers.tpl
+++ b/templates/infrastructure/immutable/butane/_helpers.tpl
@@ -99,14 +99,7 @@ passwd:
 {{- end }}
 {{- end }}
 
-{{- /*
-  User-provided additional disks: storage.disks + storage.filesystems + mount units.
-  Shared by every role — the schema puts additionalDisks on Node.Storage, which all four
-  roles share, so a role that omitted this block would accept the config and silently
-  drop it. Unlike network or systemd config, this cannot be worked around with
-  storage.files: Ignition runs disks -> filesystems -> files, so files are written after
-  the filesystem is already mounted and cannot partition a device.
-*/}}
+{{- /* Shared by all roles: the schema puts additionalDisks on Node.Storage, which all four share. */}}
 {{- define "additional-disks" }}
 {{- if hasKeyAny .node.storage "additionalDisks" }}
   disks:

--- a/templates/infrastructure/immutable/butane/controlplane.bu.tpl
+++ b/templates/infrastructure/immutable/butane/controlplane.bu.tpl
@@ -44,6 +44,9 @@ storage:
 {{ .node.storage.directories | toYaml | indent 4 }}
 {{- end }}
 
+  # User-provided additional disks
+{{- template "additional-disks" . }}
+
 systemd:
   units:
     # Disable all automatic updates - sysext and OS updates are manual-only in production

--- a/templates/infrastructure/immutable/butane/etcd.bu.tpl
+++ b/templates/infrastructure/immutable/butane/etcd.bu.tpl
@@ -48,6 +48,9 @@ storage:
 {{ .node.storage.directories | toYaml | indent 4 }}
 {{- end }}
 
+  # User-provided additional disks
+{{- template "additional-disks" . }}
+
 systemd:
   units:
     # Disable all automatic updates - sysext and OS updates are manual-only in production

--- a/templates/infrastructure/immutable/butane/loadbalancer.bu.tpl
+++ b/templates/infrastructure/immutable/butane/loadbalancer.bu.tpl
@@ -40,6 +40,9 @@ storage:
 {{ .node.storage.directories | toYaml | indent 4 }}
 {{- end }}
 
+  # User-provided additional disks
+{{- template "additional-disks" . }}
+
 systemd:
   units:
     # Disable all automatic updates - sysext and OS updates are manual-only in production

--- a/templates/infrastructure/immutable/butane/worker.bu.tpl
+++ b/templates/infrastructure/immutable/butane/worker.bu.tpl
@@ -40,6 +40,9 @@ storage:
 {{ .node.storage.directories | toYaml | indent 4 }}
 {{- end }}
 
+  # User-provided additional disks
+{{- template "additional-disks" . }}
+
 systemd:
   units:
     # Disable all automatic updates - sysext and OS updates are manual-only in production


### PR DESCRIPTION
<!--
PR body draft (NOT posted).
Repo:   sighupio/distribution
Branch: fix/missing-field-butate-template -> main   (base: c30b7158)
Title:  feat(immutable/butane): render storage.additionalDisks on all node roles
Sigue .github/pull_request_template.md
-->

### Summary 💡

`spec.infrastructure.nodes[].storage.additionalDisks` is declared in the Immutable schema and accepted by `furyctl validate config`, but no butane template ever read it — the config was silently discarded and the disk never created. This renders it, for all four node roles, via a shared `_helpers.tpl` block.

`git log --all -S'additionalDisks'` over the butane templates returns **zero commits in the repo's history**: this was never implemented, in any released version. It is also the only unrendered schema field with **no workaround** — Ignition applies storage as `disks → raid → luks → filesystems → files`, so `storage.files` is written after the filesystem is mounted and cannot partition a device.

Closes: #556

Relates: <!-- los issues 03 (tests/templates sin immutable) y 02 (15 campos muertos restantes) cuando se abran -->

### Description 📝

**5 files, +48/−0, 2 commits. Templates only — no schema change, no furyctl change.**

- `butane/_helpers.tpl` (+36): new `{{- define "additional-disks" }}` that transcribes the schema 1:1 into butane `storage.disks` + `storage.filesystems`.
- `butane/{worker,controlplane,etcd,loadbalancer}.bu.tpl` (+3 each): `{{- template "additional-disks" . }}`, placed after the `directories` block.

**Why a shared block and not one per role.** The schema puts `additionalDisks` on `Spec.Infrastructure.Node.Storage`, which all four roles share. Copying the block into each template guarantees they drift; a role that omitted it would accept the config and drop it — the same bug, smaller.

**Why all four roles.** `tests/schemas/public/immutable-kfd-v1alpha2/002-ok.yaml` (`metadata.name: production-cluster-advanced`, asserted **valid** by the schema suite) already declares `additionalDisks` on control planes → `/var/lib/etcd` (`:36,92,120`) and load balancers → `/var/lib/kubelet` (`:149,178`). etcd on a dedicated data disk is the feature's obvious purpose.

**No furyctl change is needed.** `furyctl/internal/apis/kfd/v1alpha2/immutable/create/infrastructure_bootsrap.go:431` passes `"node": rawNode` — the raw `map[any]any` from YAML, not the typed struct. This is deliberate (documented at `:134-144` and `public/schema.go:50`) and covered by `TestRawNodesByHostnamePassesThroughEveryField`, which asserts `additionalDisks` passthrough explicitly. The value already reached the template; nothing read it.

**Decisions baked in, and their costs:**

| Choice | Rationale / cost |
|---|---|
| `wipe_table: true`, `wipe_filesystem: true` hardcoded | Always destructive; an existing disk cannot be attached without being wiped. Defensible for immutable infra, but it is not *selectable* — Butane exposes both knobs precisely to allow saying no. Not exposed because the schema does not model them. |
| `device` derived as `/dev/disk/by-partlabel/<label>` | Stable against disk reordering. Requires `label` to be unique per node; the schema does not enforce that. |
| `with_mount_unit: true` hardcoded | Wanted in every known case. |
| `{{- if .sizeMiB }}` (truthiness) | `sizeMiB: 0` omits `size_mib` → partition fills the disk, matching the schema's documented "0 = use all available space". Correct, but by Go-template truthiness rather than intent. `sizeMiB` is `required` with `minimum: 0`, so "unset" cannot occur and this is currently harmless. |

### Breaking Changes 💔

None.

- Nodes that do **not** declare `additionalDisks` render byte-identically except for one comment line + blank, matching the existing `# User-provided additional directories` pattern (which is likewise emitted outside its guard). Verified by diffing renders against `git show HEAD:` templates.
- Nodes that **do** declare it previously got nothing; now they get the disk they asked for. That is the fix, not a break.
- No schema change, so no config becomes invalid.

### Tests performed 🧪

- [x] **Real boot, 6 nodes, SD 1.35.0 / furyctl 0.35.0** — `furyctl apply --distro-location ../distribution`, all nodes reached `booted`, then verified over SSH:

  ```
  cp1  → vda    4G
         └─vda1 4G xfs ETCD       /var/lib/etcd
         findmnt: /dev/vda1 xfs rw,noatime,...    unit var-lib-etcd.mount: active
         df: 232M used   contents: member/        ← etcd actually writing to it

  worker1-3 → vda1 4G xfs CONTAINERD /var/lib/containerd
         findmnt: /dev/vda1 xfs rw,noatime,...    unit var-lib-containerd.mount: active
         df: 110M used   contents: io.containerd.content.v1.content, metadata.v1.bolt,
                                   snapshotter.v1.blockfile   ← containerd writing to it

  lb1/lb2 → no vda at all (they declare no additionalDisks)
  ```
  A control plane with etcd on a dedicated disk — the case the schema has accepted since `a6fd0f58` (2025-11) and no template ever wrote.

- [x] **`butane -c --strict`** on every rendered `.bu`: **12/12** (fury-talk) and **16/16** (a 3-cp cluster). `--strict` fails on any warning.
- [x] **Ignition output** inspected (the artifact actually served over PXE), not just the butane:
  ```json
  disks:       [{"device": "/dev/vda", "partitions": [{"label": "etcd-data", "number": 1}], "wipeTable": true}]
  filesystems: [{"device": "/dev/disk/by-partlabel/etcd-data", "format": "xfs", "label": "ETCD",
                 "mountOptions": ["noatime"], "path": "/var/lib/etcd", "wipeFilesystem": true}]
  systemd:     var-lib-etcd.mount
  ```
- [x] **Render test with mutation check** — renders the templates through furyctl's own func map, then converts each `.bu` with `coreos/butane v0.28.0` (variant `flatcar` 1.1.0). 6 cases: `002-ok`/ctrl01 (`/var/lib/etcd`), `002-ok`/lb01 (`/var/lib/kubelet`), a real worker, plus three no-disk cases asserting **absence** of `disks:`. **Verified the test bites**: against `git show HEAD:` templates it fails **0/6**. A test that has never failed proves nothing.
- [x] **No regression**: byte-diffed renders old-vs-new for nodes without `additionalDisks` — only the comment line differs.
- [x] **`furyctl validate config`** passes on configs declaring the field on a control plane (previously it also passed, and rendered nothing).

Not tested: `mise run test:templates:regressions` does **not** cover this — `tests/templates/` has no `immutable/`. That gap is the root cause of this bug and is filed separately; every test above had to be built by hand.

### Future work 🔧

- **`tests/templates/immutable/`** (filed separately) — the root cause. `tests/templates/` has baselines for `ekscluster`, `kfddistribution` and `onpremises` only, so nothing in CI renders these templates. Without it this class of bug returns silently. The render test used above is a working prototype.
- **15 further dead leaves** under `spec.infrastructure` (`bonds`, global `kernelParameters`, `nameservers.search`, `loadBalancers.members[].ip`) — filed separately, deliberately without a proposed fix: each needs a product decision (render vs remove from schema), and unlike `additionalDisks` all of them have a `storage.files` workaround.
- **Expose the wipe knobs.** `wipe_table` / `wipe_filesystem` are hardcoded `true`. If attaching a pre-existing disk is ever a requirement, the schema needs those fields.
- **`sizeMiB: 0`** relies on template truthiness rather than an explicit check; worth an explicit `hasKey` if this code is touched again.

### Self-assessment checklist 🏁

- [x] My PR has a clear scope and does not mix together several unrelated changes — only `additionalDisks`; the other dead fields found in the same audit are deliberately left out
- [ ] I've updated the `docs/releases/unreleased.md` file (or equivalent) — **pending**: entry goes under **Bug fixes 🐞** once this PR has a number
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [ ] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds — Immutable only. `templates/infrastructure/immutable/` is not shared with EKSCluster / KFDDistribution / OnPremises; verified no other kind reads `additionalDisks`
- [ ] CI is green — **verify after opening**
