### PR TITLE
fix(templates): fetch admin.conf from whichever master actually has it

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -16,6 +16,8 @@ Welcome to the latest release of SD maintained by SIGHUP by ReeVo team.
 - [[#561](https://github.com/sighupio/distribution/pull/561)] Immutable: align possible properties for Kubernetes phase `kubeletConfiguration` parameter with OnPremises, accepting all possible values now.
 - [[#564](https://github.com/sighupio/distribution/pull/564)] OnPremises: fixed a race in the preflight `verify-playbook.yaml` where fetching `admin.conf` from multiple masters in parallel could randomly fail with a checksum mismatch.
 - [[#568](https://github.com/sighupio/distribution/pull/568)] Immutable: actually set the search domains for an interface if it is defined in the node configuration, this value was being ignored until now.
+- [[#577](https://github.com/sighupio/distribution/pull/577)] Makes the admin.conf fetch in verify-playbook.yaml pick the right master, and stops the playbook from failing on purpose to signal "cluster doesn't exist".
+
 
 ## Breaking Changes 💔
 

--- a/templates/preflight/onpremises/verify-playbook.yaml
+++ b/templates/preflight/onpremises/verify-playbook.yaml
@@ -11,15 +11,6 @@
         path: /etc/kubernetes/admin.conf
       register: admin_conf_stat
 
-    - name: Getting admin.conf kubeconfig
-      become: yes
-      fetch:
-        src: /etc/kubernetes/admin.conf
-        dest: "{{ kubernetes_kubeconfig_path }}/admin.conf"
-        flat: yes
-      when: admin_conf_stat.stat.exists
-      run_once: true
-
     - name: Set fact if admin.conf exists
       set_fact:
         admin_conf_exists: "{{ admin_conf_stat.stat.exists }}"
@@ -28,18 +19,20 @@
 - name: Aggregate results and fetch admin.conf
   hosts: master
   tasks:
-    - name: Initialize any_master_has_conf
+    - name: Pick a master that has admin.conf
       set_fact:
-        any_master_has_conf: false
-
-    - name: Check if any master has admin.conf
-      set_fact:
-        any_master_has_conf: "{{ any_master_has_conf or hostvars[item].admin_conf_exists }}"
+        admin_conf_host: "{{ item }}"
       loop: "{{ groups['master'] }}"
-      when: hostvars[item].admin_conf_exists is defined
+      when:
+        - admin_conf_host is not defined
+        - hostvars[item].admin_conf_exists is defined
 
-    - name: Fail if no master has admin.conf
-      fail:
-        msg: "No master node has /etc/kubernetes/admin.conf"
-      when: not any_master_has_conf
- 
+    - name: Getting admin.conf kubeconfig
+      become: yes
+      fetch:
+        src: /etc/kubernetes/admin.conf
+        dest: "{{ kubernetes_kubeconfig_path }}/admin.conf"
+        flat: yes
+      delegate_to: "{{ admin_conf_host | default(inventory_hostname) }}"
+      when: admin_conf_host is defined
+      run_once: true


### PR DESCRIPTION
### Summary 💡

Makes the admin.conf fetch in `verify-playbook.yaml` pick the right master regardless of Ansible's host ordering, and stops the playbook from failing on purpose to signal "cluster doesn't exist", so furyctl can tell that case apart from a real failure.

Relates:
- sighupio/furyctl#717
- #387

### Description 📝

`verify-playbook.yaml` used a `fail:` task as its only way to tell furyctl "no master has admin.conf yet". Furyctl only ever checked whether the playbook succeeded or failed, so any other kind of failure (a host unreachable, a checksum mismatch during the fetch) looked identical to "cluster doesn't exist" on the furyctl side.

This PR:
- Removes the `fail:` task. The playbook now completes cleanly whenever nothing goes wrong, whether or not a master has admin.conf.
- Picks the master to fetch from explicitly (`admin_conf_host`, using the same aggregation #387 introduced), and fetches with `delegate_to` instead of relying on `run_once`'s default host selection.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested a cluster creation. Still correctly recognized as "cluster doesn't exist".
- [x] Tested a plain `apply` on an existing cluster.
- [x] Tested a real `--upgrade` with a `distributionVersion` change. Diff still correctly detected, real kubeadm upgrade path runs.
- [x] Tested a forced local failure (fetch destination not reachable). Now fails with an explicit error instead of "cluster doesn't exist".
- [x] Tested a forced Ansible failure. Fails with an explicit error.
- [x] Tested adding a 4th control-plane node in `masters.hosts`, simulating an immutable edit. Cluster still correctly recognized as existing and the immutability check on `masters.hosts.*` correctly blocked the change.


### Future work 🔧

Apply the same fix to the Immutable kind

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green