### PR TITLE
fix(onpremises): check pkiFolder min length

### DIFF
--- a/docs/schemas/onpremises-kfd-v1alpha2.md
+++ b/docs/schemas/onpremises-kfd-v1alpha2.md
@@ -6433,6 +6433,10 @@ Name for the node group. It will be also used as the node role label. It should 
 
 The path to the folder where the PKI files for Kubernetes and etcd are stored.
 
+### Constraints
+
+**minimum length**: the minimum number of characters for this string is: `1`
+
 ## .spec.kubernetes.podCidr
 
 ### Description

--- a/schemas/public/onpremises-kfd-v1alpha2.json
+++ b/schemas/public/onpremises-kfd-v1alpha2.json
@@ -77,6 +77,7 @@
       "properties": {
         "pkiFolder": {
           "type": "string",
+          "minLength": 1,
           "description": "The path to the folder where the PKI files for Kubernetes and etcd are stored."
         },
         "ssh": {

--- a/tests/e2e/onpremises/tests/schema.sh
+++ b/tests/e2e/onpremises/tests/schema.sh
@@ -166,3 +166,9 @@ test_schema() {
 
     test_schema "public" "onpremises-kfd-v1alpha2" "005-ok" expect_ok
 }
+
+@test "006 - no (empty pkiFolder)" {
+    info
+
+    test_schema "public" "onpremises-kfd-v1alpha2" "006-no" expect_no
+}

--- a/tests/schemas/public/onpremises-kfd-v1alpha2/006-no.yaml
+++ b/tests/schemas/public/onpremises-kfd-v1alpha2/006-no.yaml
@@ -1,0 +1,77 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Tests the following cases:
+
+# Given a valid OnPremises config
+# And some host entries under masters, etcd, workers, and loadBalancers have a per-host "dnsZone" field
+# When I validate the config against the schema
+# Then no errors are returned
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: OnPremises
+metadata:
+  name: onpremises-test-per-host-dnszone
+spec:
+  distributionVersion: dummy
+  kubernetes:
+    pkiFolder: ""
+    ssh:
+      username: user
+      keyPath: ~/.ssh/id_rsa
+    dnsZone: k8s.local
+    controlPlaneAddress: api.k8s.local
+    podCidr: 10.0.0.0/16
+    svcCidr: 10.1.0.0/16
+    loadBalancers:
+      enabled: true
+      hosts:
+        - name: lb-0
+          ip: 192.168.1.10
+          dnsZone: k8s.cloud
+      keepalived:
+        enabled: false
+      stats:
+        username: admin
+        password: admin
+    masters:
+      hosts:
+        - name: master-0
+          ip: 192.168.1.1
+        - name: master-1
+          ip: 192.168.1.2
+          dnsZone: k8s.cloud
+    etcd:
+      hosts:
+        - name: etcd-0
+          ip: 192.168.1.5
+        - name: etcd-1
+          ip: 192.168.1.6
+          dnsZone: k8s.cloud
+    nodes:
+      - name: workers
+        hosts:
+          - name: worker-0
+            ip: 192.168.1.20
+          - name: worker-1
+            ip: 192.168.1.21
+            dnsZone: k8s.cloud
+  distribution:
+    modules:
+      dr:
+        type: none
+      ingress:
+        baseDomain: example.local
+        nginx:
+          type: single
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-example
+            email: example@example.local
+            type: http01
+      logging:
+        type: none
+      policy:
+        type: none


### PR DESCRIPTION
### Summary 💡

Add constraint for the `.kubernetes.pkiFolder` minimum length, otherwise an empty string would have been accepted as a valid value, breaking the deployment down the line and making the ansible roles unexpectedly on multi control plane nodes.

Relates:
- #585 

### Description 📝

Add constraint for the pkiFolder minimum length, otherwise an empty string would have been accepted as a valid value, breaking the deployment down the line and making the ansible roles unexpectedly on multi control plane nodes.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Schema tests passing

### Future work 🔧

Validate that the folder actually exists and has the right files.

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
~~- [ ] I've updated the `docs/releases/unreleased.md` file (or equivalent)~~
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

