### PR TITLE
feat: add the kubeconfigs renewal playbooks

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -4,7 +4,7 @@ Welcome to the latest release of SD maintained by SIGHUP by ReeVo team.
 
 ## New features 🌟
 
-- [[#575](https://github.com/sighupio/furyctl/issues/575)] OnPremises and Immutable: add support for the new `furyctl renew kubeconfigs` command. It renews the kubeconfig file of the admin and the kubeconfig files of the users in `spec.kubernetes.advanced.users.names`. Then it downloads them to the working directory. A user that you add to the configuration file gets a kubeconfig file. It is not necessary to apply the kubernetes phase.
+- [[#575](https://github.com/sighupio/furyctl/issues/575)] OnPremises and Immutable: add support for the new [`furyctl renew kubeconfigs`](https://github.com/sighupio/distribution/pull/588) command. It renews the kubeconfig file of the admin and the kubeconfig files of the users in `spec.kubernetes.advanced.users.names`. Then it downloads them to the working directory. A user that you add to the configuration file gets a kubeconfig file. It is not necessary to apply the kubernetes phase.
 
 ## Bug fixes 🐞
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -4,7 +4,7 @@ Welcome to the latest release of SD maintained by SIGHUP by ReeVo team.
 
 ## New features 🌟
 
-TBD
+- [[#575](https://github.com/sighupio/furyctl/issues/575)] OnPremises and Immutable: add support for the new `furyctl renew kubeconfigs` command. It renews the kubeconfig file of the admin and the kubeconfig files of the users in `spec.kubernetes.advanced.users.names`. Then it downloads them to the working directory. A user that you add to the configuration file gets a kubeconfig file. It is not necessary to apply the kubernetes phase.
 
 ## Bug fixes 🐞
 

--- a/templates/kubernetes/immutable/renew-kubeconfigs.yaml
+++ b/templates/kubernetes/immutable/renew-kubeconfigs.yaml
@@ -1,0 +1,73 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+#
+# Kubernetes kubeconfig files renewal playbook
+#
+# This playbook renews the kubeconfig files of the cluster. It does these steps:
+#   1. It renews the client certificate in `admin.conf` on each control plane node.
+#   2. It writes new kubeconfig files for the users in `spec.kubernetes.advanced.users.names`.
+#   3. It downloads the renewed kubeconfig files to the local machine.
+#
+# The client certificates in the kubeconfig files are valid for one year. On a control plane node,
+# run this command to read the expiration date:
+#
+#   kubectl config view --raw -o jsonpath="{.users[0].user.client-certificate-data}" --kubeconfig=/etc/kubernetes/admin.conf |
+#   base64 -d | openssl x509 -noout -text | grep After
+#
+# `renew_kubeconfigs_users` is the list of the kubeconfig files to renew. furyctl sets it with the
+# `-e` flag, as JSON. The default value renews all of them.
+
+- name: Renew the Kubernetes kubeconfig files
+  hosts: control_plane
+  become: true
+  vars:
+    # This playbook does not use the kube-control-plane role, thus it must set the role defaults again.
+    kubeadm_config_file: /etc/kubernetes/kubeadm.yml
+    kubernetes_users_kubeconfig_dir: /etc/kubernetes/users
+    renew_kubeconfigs_users: "{{ ['admin'] + (kubernetes_users_names | default([], true)) }}"
+  tasks:
+    - name: Select the kubeconfig files to renew
+      ansible.builtin.set_fact:
+        renew_admin_kubeconfig: "{{ 'admin' in renew_kubeconfigs_users }}"
+        renew_users_kubeconfigs: "{{ renew_kubeconfigs_users | difference(['admin']) }}"
+
+    - name: Renew the admin.conf client certificate
+      ansible.builtin.command: kubeadm certs renew admin.conf
+      when: renew_admin_kubeconfig | bool
+
+    - name: Download the admin.conf kubeconfig file
+      run_once: true
+      ansible.builtin.fetch:
+        src: /etc/kubernetes/admin.conf
+        dest: "{{ kubernetes_kubeconfig_path }}/admin.conf"
+        flat: true
+      when: renew_admin_kubeconfig | bool
+
+    - name: Make the users kubeconfig folder
+      run_once: true
+      ansible.builtin.file:
+        name: "{{ kubernetes_users_kubeconfig_dir }}"
+        state: directory
+      when: renew_users_kubeconfigs | length > 0
+
+    - name: Generate again the users kubeconfig files with kubeadm
+      run_once: true
+      ansible.builtin.shell: "kubeadm kubeconfig user --config={{ kubeadm_config_file }} --client-name={{ item }} --org={{ kubernetes_users_org | default('sighup', true) }} > {{ kubernetes_users_kubeconfig_dir }}/{{ item }}.kubeconfig"
+      with_items: "{{ renew_users_kubeconfigs }}"
+
+    - name: Set the Kubernetes API server address in the generated kubeconfig files
+      run_once: true
+      ansible.builtin.replace:
+        path: "{{ kubernetes_users_kubeconfig_dir }}/{{ item }}.kubeconfig"
+        regexp: '^(\s*server: https://).*$'
+        replace: '\1{{ kubernetes_control_plane_address }}'
+      with_items: "{{ renew_users_kubeconfigs }}"
+
+    - name: Download the users kubeconfig files
+      run_once: true
+      ansible.builtin.fetch:
+        src: "{{ kubernetes_users_kubeconfig_dir }}/{{ item }}.kubeconfig"
+        dest: "{{ kubernetes_kubeconfig_path }}/{{ item }}.kubeconfig"
+        flat: true
+      with_items: "{{ renew_users_kubeconfigs }}"

--- a/templates/kubernetes/immutable/renew-kubeconfigs.yaml
+++ b/templates/kubernetes/immutable/renew-kubeconfigs.yaml
@@ -53,7 +53,8 @@
 
     - name: Generate again the users kubeconfig files with kubeadm
       run_once: true
-      ansible.builtin.shell: "kubeadm kubeconfig user --config={{ kubeadm_config_file }} --client-name={{ item }} --org={{ kubernetes_users_org | default('sighup', true) }} > {{ kubernetes_users_kubeconfig_dir }}/{{ item }}.kubeconfig"
+      # The values go into a shell command, thus they are quoted: a user name can contain a space.
+      ansible.builtin.shell: "kubeadm kubeconfig user --config={{ kubeadm_config_file }} --client-name={{ item | quote }} --org={{ kubernetes_users_org | default('sighup', true) | quote }} > {{ (kubernetes_users_kubeconfig_dir ~ '/' ~ item ~ '.kubeconfig') | quote }}"
       with_items: "{{ renew_users_kubeconfigs }}"
 
     - name: Set the Kubernetes API server address in the generated kubeconfig files

--- a/templates/kubernetes/onpremises/99.cluster-kubeconfigs-renewal.yaml
+++ b/templates/kubernetes/onpremises/99.cluster-kubeconfigs-renewal.yaml
@@ -53,7 +53,8 @@
 
     - name: Generate again the users kubeconfig files with kubeadm
       run_once: true
-      ansible.builtin.shell: "kubeadm kubeconfig user --config={{ kubeadm_config_file }} --client-name={{ item }} --org={{ kubernetes_users_org | default('sighup', true) }} > {{ kubernetes_users_kubeconfig_dir }}/{{ item }}.kubeconfig"
+      # The values go into a shell command, thus they are quoted: a user name can contain a space.
+      ansible.builtin.shell: "kubeadm kubeconfig user --config={{ kubeadm_config_file }} --client-name={{ item | quote }} --org={{ kubernetes_users_org | default('sighup', true) | quote }} > {{ (kubernetes_users_kubeconfig_dir ~ '/' ~ item ~ '.kubeconfig') | quote }}"
       with_items: "{{ renew_users_kubeconfigs }}"
 
     - name: Set the Kubernetes API server address in the generated kubeconfig files

--- a/templates/kubernetes/onpremises/99.cluster-kubeconfigs-renewal.yaml
+++ b/templates/kubernetes/onpremises/99.cluster-kubeconfigs-renewal.yaml
@@ -1,0 +1,73 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+#
+# Kubernetes kubeconfig files renewal playbook
+#
+# This playbook renews the kubeconfig files of the cluster. It does these steps:
+#   1. It renews the client certificate in `admin.conf` on each control plane node.
+#   2. It writes new kubeconfig files for the users in `spec.kubernetes.advanced.users.names`.
+#   3. It downloads the renewed kubeconfig files to the local machine.
+#
+# The client certificates in the kubeconfig files are valid for one year. On a control plane node,
+# run this command to read the expiration date:
+#
+#   kubectl config view --raw -o jsonpath="{.users[0].user.client-certificate-data}" --kubeconfig=/etc/kubernetes/admin.conf |
+#   base64 -d | openssl x509 -noout -text | grep After
+#
+# `renew_kubeconfigs_users` is the list of the kubeconfig files to renew. furyctl sets it with the
+# `-e` flag, as JSON. The default value renews all of them.
+
+- name: Renew the Kubernetes kubeconfig files
+  hosts: master
+  become: true
+  vars:
+    # This playbook does not use the kube-control-plane role, thus it must set the role defaults again.
+    kubeadm_config_file: /etc/kubernetes/kubeadm.yml
+    kubernetes_users_kubeconfig_dir: /etc/kubernetes/users
+    renew_kubeconfigs_users: "{{ ['admin'] + (kubernetes_users_names | default([], true)) }}"
+  tasks:
+    - name: Select the kubeconfig files to renew
+      ansible.builtin.set_fact:
+        renew_admin_kubeconfig: "{{ 'admin' in renew_kubeconfigs_users }}"
+        renew_users_kubeconfigs: "{{ renew_kubeconfigs_users | difference(['admin']) }}"
+
+    - name: Renew the admin.conf client certificate
+      ansible.builtin.command: kubeadm certs renew admin.conf
+      when: renew_admin_kubeconfig | bool
+
+    - name: Download the admin.conf kubeconfig file
+      run_once: true
+      ansible.builtin.fetch:
+        src: /etc/kubernetes/admin.conf
+        dest: "{{ kubernetes_kubeconfig_path }}/admin.conf"
+        flat: true
+      when: renew_admin_kubeconfig | bool
+
+    - name: Make the users kubeconfig folder
+      run_once: true
+      ansible.builtin.file:
+        name: "{{ kubernetes_users_kubeconfig_dir }}"
+        state: directory
+      when: renew_users_kubeconfigs | length > 0
+
+    - name: Generate again the users kubeconfig files with kubeadm
+      run_once: true
+      ansible.builtin.shell: "kubeadm kubeconfig user --config={{ kubeadm_config_file }} --client-name={{ item }} --org={{ kubernetes_users_org | default('sighup', true) }} > {{ kubernetes_users_kubeconfig_dir }}/{{ item }}.kubeconfig"
+      with_items: "{{ renew_users_kubeconfigs }}"
+
+    - name: Set the Kubernetes API server address in the generated kubeconfig files
+      run_once: true
+      ansible.builtin.replace:
+        path: "{{ kubernetes_users_kubeconfig_dir }}/{{ item }}.kubeconfig"
+        regexp: '^(\s*server: https://).*$'
+        replace: '\1{{ kubernetes_control_plane_address }}'
+      with_items: "{{ renew_users_kubeconfigs }}"
+
+    - name: Download the users kubeconfig files
+      run_once: true
+      ansible.builtin.fetch:
+        src: "{{ kubernetes_users_kubeconfig_dir }}/{{ item }}.kubeconfig"
+        dest: "{{ kubernetes_kubeconfig_path }}/{{ item }}.kubeconfig"
+        flat: true
+      with_items: "{{ renew_users_kubeconfigs }}"


### PR DESCRIPTION
### Summary 💡

Add a playbook that renews the kubeconfig files of a cluster, for the OnPremises and the Immutable kinds. It backs the new `furyctl renew kubeconfigs` command.

Closes:

Relates: sighupio/furyctl#575, sighupio/furyctl#575

### Description 📝

New playbooks:

- `templates/kubernetes/onpremises/99.cluster-kubeconfigs-renewal.yaml`
- `templates/kubernetes/immutable/renew-kubeconfigs.yaml`

The playbook does these steps:

1. It renews the client certificate in `admin.conf` on each control plane node.
2. It writes new kubeconfig files for the users in `spec.kubernetes.advanced.users.names`, then it sets the API server address in the generated files.
3. It downloads the renewed kubeconfig files to the local machine.

The `renew_kubeconfigs_users` variable selects which kubeconfig files to renew. furyctl sets it with the `-e` flag, as JSON. The default value renews all of them.

The playbook targets the OnPremises and the Immutable kinds only. The other kinds do not have a cluster PKI that furyctl controls.

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] Tested end to end on an Immutable cluster, together with the furyctl PR
- [x] The downloaded kubeconfig files work with `kubectl --kubeconfig`
- [x] `ansible-playbook --syntax-check` passes for both playbooks
- [x] Selection logic run through ansible: no filter, one user, admin only, and a user name that contains a space

### Future work 🔧

None

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green
