### PR TITLE
chore: update Kubernetes certification badge to version 1.35 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ SD has been certified by the [CNCF] (Cloud Native Computing Foundation) as a _Ce
 
 <!-- markdownlint-disable MD033 -->
 <p align="center">
-    <a href="https://github.com/cncf/k8s-conformance/pull/4126">
-        <img src="https://raw.githubusercontent.com/cncf/artwork/main/projects/kubernetes/certified-kubernetes/versionless/pantone/certified-kubernetes-pantone.svg" width="120" alt="SD is CNCF Certified Kubernetes 1.34 - click to see the certification PR"/>
+    <a href="https://github.com/cncf/k8s-conformance/pull/4316">
+        <img src="https://raw.githubusercontent.com/cncf/artwork/main/projects/kubernetes/certified-kubernetes/versionless/pantone/certified-kubernetes-pantone.svg" width="120" alt="SD is CNCF Certified Kubernetes 1.35 - click to see the certification PR"/>
     </a>
 </p>
 <!-- markdownlint-enable MD033 -->


### PR DESCRIPTION
chore: update Kubernetes certification badge to version 1.35 in README