### PR TITLE
docs(schemas): recommend secretbox for the encryption at rest

### DIFF
--- a/docs/schemas/immutable-kfd-v1alpha2.md
+++ b/docs/schemas/immutable-kfd-v1alpha2.md
@@ -7168,21 +7168,27 @@ Maximum number of terminated Pods retained by the controller-manager before auto
 
 ### Description
 
-etcd's encryption at rest configuration. Must be a string with the EncryptionConfiguration object in YAML. Example:
+etcd's encryption at rest configuration. Must be a string with the EncryptionConfiguration object in YAML. Check the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/) for the providers that the API server accepts and for the properties of each one.
+
+Example:
 
 ```yaml
-
 apiVersion: apiserver.config.k8s.io/v1
 kind: EncryptionConfiguration
 resources:
   - resources:
-    - secrets
+      - secrets
     providers:
-    - aescbc:
-        keys:
-        - name: mykey
-          secret: base64_encoded_secret
+      - secretbox:
+          keys:
+            - name: key1
+              secret: base64_encoded_key
+      - identity: {}
 ```
+
+The `secretbox` provider of the example needs a 256-bit key in base64. To generate a random key, run the following command: `head -c32 /dev/urandom | base64`
+
+The `identity` provider comes last in the example, whatever the provider before it is: without `identity`, the API server cannot read the secrets that etcd holds with no encryption.
 
 
 ## .spec.kubernetes.advanced.encryption.tlsCipherSuites

--- a/docs/schemas/onpremises-kfd-v1alpha2.md
+++ b/docs/schemas/onpremises-kfd-v1alpha2.md
@@ -5635,21 +5635,27 @@ Maximum number of terminated Pods retained by the controller-manager before auto
 
 ### Description
 
-etcd's encryption at rest configuration. Must be a string with the EncryptionConfiguration object in YAML. Example:
+etcd's encryption at rest configuration. Must be a string with the EncryptionConfiguration object in YAML. Check the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/) for the providers that the API server accepts and for the properties of each one.
+
+Example:
 
 ```yaml
-
 apiVersion: apiserver.config.k8s.io/v1
 kind: EncryptionConfiguration
 resources:
   - resources:
-    - secrets
+      - secrets
     providers:
-    - aescbc:
-        keys:
-        - name: mykey
-          secret: base64_encoded_secret
+      - secretbox:
+          keys:
+            - name: key1
+              secret: base64_encoded_key
+      - identity: {}
 ```
+
+The `secretbox` provider of the example needs a 256-bit key in base64. To generate a random key, run the following command: `head -c32 /dev/urandom | base64`
+
+The `identity` provider comes last in the example, whatever the provider before it is: without `identity`, the API server cannot read the secrets that etcd holds with no encryption.
 
 
 ## .spec.kubernetes.advanced.encryption.tlsCipherSuites

--- a/schemas/public/immutable-kfd-v1alpha2.json
+++ b/schemas/public/immutable-kfd-v1alpha2.json
@@ -1669,7 +1669,7 @@
         },
         "configuration": {
           "type": "string",
-          "description": "etcd's encryption at rest configuration. Must be a string with the EncryptionConfiguration object in YAML. Example:\n\n```yaml\n\napiVersion: apiserver.config.k8s.io/v1\nkind: EncryptionConfiguration\nresources:\n  - resources:\n    - secrets\n    providers:\n    - aescbc:\n        keys:\n        - name: mykey\n          secret: base64_encoded_secret\n```\n"
+          "description": "etcd's encryption at rest configuration. Must be a string with the EncryptionConfiguration object in YAML. Check the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/) for the providers that the API server accepts and for the properties of each one.\n\nExample:\n\n```yaml\napiVersion: apiserver.config.k8s.io/v1\nkind: EncryptionConfiguration\nresources:\n  - resources:\n      - secrets\n    providers:\n      - secretbox:\n          keys:\n            - name: key1\n              secret: base64_encoded_key\n      - identity: {}\n```\n\nThe `secretbox` provider of the example needs a 256-bit key in base64. To generate a random key, run the following command: `head -c32 /dev/urandom | base64`\n\nThe `identity` provider comes last in the example, whatever the provider before it is: without `identity`, the API server cannot read the secrets that etcd holds with no encryption.\n"
         }
       }
     },

--- a/schemas/public/onpremises-kfd-v1alpha2.json
+++ b/schemas/public/onpremises-kfd-v1alpha2.json
@@ -771,7 +771,7 @@
         },
         "configuration": {
           "type": "string",
-          "description": "etcd's encryption at rest configuration. Must be a string with the EncryptionConfiguration object in YAML. Example:\n\n```yaml\n\napiVersion: apiserver.config.k8s.io/v1\nkind: EncryptionConfiguration\nresources:\n  - resources:\n    - secrets\n    providers:\n    - aescbc:\n        keys:\n        - name: mykey\n          secret: base64_encoded_secret\n```\n"
+          "description": "etcd's encryption at rest configuration. Must be a string with the EncryptionConfiguration object in YAML. Check the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/) for the providers that the API server accepts and for the properties of each one.\n\nExample:\n\n```yaml\napiVersion: apiserver.config.k8s.io/v1\nkind: EncryptionConfiguration\nresources:\n  - resources:\n      - secrets\n    providers:\n      - secretbox:\n          keys:\n            - name: key1\n              secret: base64_encoded_key\n      - identity: {}\n```\n\nThe `secretbox` provider of the example needs a 256-bit key in base64. To generate a random key, run the following command: `head -c32 /dev/urandom | base64`\n\nThe `identity` provider comes last in the example, whatever the provider before it is: without `identity`, the API server cannot read the secrets that etcd holds with no encryption.\n"
         }
       }
     },

--- a/tests/e2e/onpremises-upgrades/config/encrypted-secret-config.yaml
+++ b/tests/e2e/onpremises-upgrades/config/encrypted-secret-config.yaml
@@ -8,10 +8,11 @@ resources:
   - resources:
     - secrets
     providers:
-    - aescbc:
+    - secretbox:
         keys:
         - name: key1
-          # base64 encoding of "passwordonatipo" (without quotes)
-          secret: cGFzc3dvcmRvbmF0aXBvCg== 
+          # base64 encoding of "passwordonatipo-passwordonatipo!" (without quotes).
+          # secretbox needs a key of 32 bytes.
+          secret: cGFzc3dvcmRvbmF0aXBvLXBhc3N3b3Jkb25hdGlwbyE=
     # as a fallback to read non encrypted secrets
     - identity: {}

--- a/tests/e2e/onpremises/config/encrypted-secret-config.yaml
+++ b/tests/e2e/onpremises/config/encrypted-secret-config.yaml
@@ -8,10 +8,11 @@ resources:
   - resources:
     - secrets
     providers:
-    - aescbc:
+    - secretbox:
         keys:
         - name: key1
-          # base64 encoding of "passwordonatipo" (without quotes)
-          secret: cGFzc3dvcmRvbmF0aXBvCg== 
+          # base64 encoding of "passwordonatipo-passwordonatipo!" (without quotes).
+          # secretbox needs a key of 32 bytes.
+          secret: cGFzc3dvcmRvbmF0aXBvLXBhc3N3b3Jkb25hdGlwbyE=
     # as a fallback to read non encrypted secrets
     - identity: {}

--- a/tests/schemas/public/immutable-kfd-v1alpha2/002-ok.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/002-ok.yaml
@@ -415,7 +415,7 @@ spec:
             - resources:
               - secrets
               providers:
-              - aescbc:
+              - secretbox:
                   keys:
                   - name: key1
                     secret: YourBase64EncodedSecretKeyHere32Bytes==


### PR DESCRIPTION
### Summary 💡

The example of `spec.kubernetes.advanced.encryption.configuration` recommends a provider that upstream Kubernetes discourages, and it omits the `identity` provider. A cluster that follows the example cannot read the secrets that etcd holds from before the encryption was on.

### Description 📝

The example in the description field for etcd encryption now uses `secretbox` instead of `aescbc`, which the Kubernetes documentation discourages because CBC with PKCS#7 padding is open to padding oracle attacks.

Added the `identity` provider as last option in the example. A cluster that copied the example and turned the encryption on after creation could no longer read its own existing secrets.

Both `OnPremises` and `Immutable` carry the same description, thus both schemas change. The `EKSCluster` and `KFDDistribution` kinds have no such field.

Updated on-premises end-to-end tests and the configuration of the immutable schema test now use the same provider.

Relates:
- sighupio/furyctl#756 which adds `furyctl create secrets`. That command
writes this object with a new key, and it follows the example of this schema.

### Breaking Changes 💔

None. The schema accepts each provider that the API server accepts, and this PRchanges an example and three test fixtures.

### Tests performed 🧪

- [x] `jv` validates both schemas after the change
- [x] `jv` validates `tests/schemas/public/immutable-kfd-v1alpha2/002-ok.yaml` against the immutable schema, which is what `bats tests/e2e/immutable/schema.sh` runs
- [x] Both end-to-end configurations parse, hold a 32-byte key, and keep `identity` as the last provider

### Future work 🔧

None

### Self-assessment checklist 🏁

- [x] My PR has a clear scope and does not mix together several unrelated changes
~~- [ ] I've updated the `docs/releases/unreleased.md` file (or equivalent)~~ N.A.
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green