### PR TITLE
fix(on-prem): rename admin.conf fetch playbook

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -9,7 +9,7 @@ Welcome to the latest release of SD maintained by SIGHUP by ReeVo team.
 ## Bug fixes 🐞
 
 - [[#581](https://github.com/sighupio/distribution/issues/581)] Immutable: node `storage.installDisk` now accepts persistent device paths like `/dev/disk/by-id/wwn-...`, `/dev/disk/by-path/...` and `/dev/mapper/...`. The field is validated the same way Butane/Ignition validates its own device fields — the path must be absolute and clean — instead of the previous alphanumeric-only pattern that rejected every `/dev/disk/by-*` symlink.
-- [[#577](https://github.com/sighupio/distribution/pull/577)] Makes the admin.conf fetch in verify-playbook.yaml pick the right master, and stops the playbook from failing on purpose to signal "cluster doesn't exist".
+- [[#577](https://github.com/sighupio/distribution/pull/577)] Makes the admin.conf fetch in fetch-admin-conf-playbook.yaml pick the right master, and stops the playbook from failing on purpose to signal "cluster doesn't exist".
 
 ## Breaking Changes 💔
 

--- a/templates/preflight/onpremises/fetch-admin-conf-playbook.yaml
+++ b/templates/preflight/onpremises/fetch-admin-conf-playbook.yaml
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-- name: Verify that the cluster exists
+- name: Check for admin.conf on master nodes
   hosts: master
   become: true
   tasks:


### PR DESCRIPTION
### Summary 💡

Renames the OnPremises `verify-playbook.yaml` to `fetch-admin-conf-playbook.yaml`, since its responsibility is now to locate and fetch `admin.conf` and not to verify that the cluster.

Relates:
- sighupio/furyctl#757
- #577

### Description 📝

After #577, a missing `admin.conf` no longer makes the playbook fail. The new name reflects its actual behavior and avoids suggesting that the playbook determines cluster existence.

The related furyctl change supports both names for compatibility with older SD versions.

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] Tested an existing cluster with SD v1.35.1 and the legacy playbook name.
- [x] Tested an upgrade from SD v1.35.1 to a mock v1.36 using the renamed playbook.
- [x] Tested a clean SD mock v1.36.0 creation.

### Future work 🔧

Apply the same to the Immutable kind if needed.

### Self-assessment checklist 🏁

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green
